### PR TITLE
fix: ensure clear command handles backup flags separately

### DIFF
--- a/cmd/clear.go
+++ b/cmd/clear.go
@@ -25,6 +25,7 @@ var (
 	clearCompleted bool
 	clearAll       bool
 	clearBackup    bool
+	clearNoBackup  bool
 )
 
 // clearCmd represents the clear command
@@ -367,11 +368,11 @@ func init() {
 	clearCmd.Flags().BoolVar(&clearCompleted, "completed", false, "Clear only completed tasks (default behavior)")
 	clearCmd.Flags().BoolVar(&clearAll, "all", false, "Clear all tasks (requires confirmation)")
 	clearCmd.Flags().BoolVar(&clearBackup, "backup", true, "Create backup before clearing (default: true)")
-	clearCmd.Flags().BoolVar(&clearBackup, "no-backup", false, "Skip backup creation")
+	clearCmd.Flags().BoolVar(&clearNoBackup, "no-backup", false, "Skip backup creation")
 
 	// Make --no-backup set backup to false
 	clearCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-		if cmd.Flag("no-backup").Changed {
+		if clearNoBackup {
 			clearBackup = false
 		}
 		return nil

--- a/cmd/clear_test.go
+++ b/cmd/clear_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+func resetClearCommandState(t *testing.T) {
+	t.Helper()
+
+	clearCmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if err := f.Value.Set(f.DefValue); err != nil {
+			t.Fatalf("reset flag %s: %v", f.Name, err)
+		}
+		f.Changed = false
+	})
+
+	clearForce = false
+	clearStatus = ""
+	clearPriority = ""
+	clearCompleted = false
+	clearAll = false
+	clearBackup = true
+	clearNoBackup = false
+}
+
+func TestClearBackupDefaultsEnabled(t *testing.T) {
+	resetClearCommandState(t)
+
+	if err := clearCmd.PreRunE(clearCmd, nil); err != nil {
+		t.Fatalf("prerun: %v", err)
+	}
+
+	if !clearBackup {
+		t.Fatalf("expected clearBackup to default to true")
+	}
+}
+
+func TestClearNoBackupFlagDisablesBackup(t *testing.T) {
+	resetClearCommandState(t)
+
+	if err := clearCmd.Flags().Set("no-backup", "true"); err != nil {
+		t.Fatalf("set no-backup: %v", err)
+	}
+
+	if err := clearCmd.PreRunE(clearCmd, nil); err != nil {
+		t.Fatalf("prerun: %v", err)
+	}
+
+	if clearBackup {
+		t.Fatalf("expected clearBackup to be false when no-backup is set")
+	}
+}
+
+func TestClearBackupFlagCanDisableBackup(t *testing.T) {
+	resetClearCommandState(t)
+
+	if err := clearCmd.Flags().Set("backup", "false"); err != nil {
+		t.Fatalf("set backup: %v", err)
+	}
+
+	if err := clearCmd.PreRunE(clearCmd, nil); err != nil {
+		t.Fatalf("prerun: %v", err)
+	}
+
+	if clearBackup {
+		t.Fatalf("expected clearBackup to respect --backup=false")
+	}
+}


### PR DESCRIPTION
## Summary
- add a dedicated variable for the `--no-backup` flag so the backup default stays true
- update the clear command pre-run hook to disable backups only when `--no-backup` is set
- add unit tests covering default backup behavior and both flags

## Testing
- go test ./cmd

------
https://chatgpt.com/codex/tasks/task_e_6903e1a045648325943fbb5f817761c6