### PR TITLE
Implement automatic policy enforcement during task completion

### DIFF
--- a/internal/app/task_policy_test.go
+++ b/internal/app/task_policy_test.go
@@ -1,0 +1,201 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/josephgoksu/TaskWing/internal/llm"
+	"github.com/josephgoksu/TaskWing/internal/memory"
+	"github.com/josephgoksu/TaskWing/internal/task"
+)
+
+// TestTaskComplete_PolicyEnforcement tests that policy violations block task completion.
+func TestTaskComplete_PolicyEnforcement(t *testing.T) {
+	// Create a temporary directory for the test
+	tmpDir, err := os.MkdirTemp("", "taskwing-policy-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create .taskwing/policies directory
+	policiesDir := filepath.Join(tmpDir, ".taskwing", "policies")
+	if err := os.MkdirAll(policiesDir, 0755); err != nil {
+		t.Fatalf("failed to create policies dir: %v", err)
+	}
+
+	// Create a test policy that blocks .env files
+	testPolicy := `package taskwing.policy
+
+import rego.v1
+
+# Block environment files
+deny contains msg if {
+    some file in input.task.files_modified
+    startswith(file, ".env")
+    msg := sprintf("BLOCKED: Environment file '%s' is protected", [file])
+}
+
+# Block GOVERNANCE.md
+deny contains msg if {
+    some file in input.task.files_modified
+    file == "GOVERNANCE.md"
+    msg := "BLOCKED: GOVERNANCE.md is a protected file"
+}
+`
+	policyPath := filepath.Join(policiesDir, "test.rego")
+	if err := os.WriteFile(policyPath, []byte(testPolicy), 0644); err != nil {
+		t.Fatalf("failed to write test policy: %v", err)
+	}
+
+	// Create .taskwing/memory directory for SQLite
+	memoryDir := filepath.Join(tmpDir, ".taskwing", "memory")
+	if err := os.MkdirAll(memoryDir, 0755); err != nil {
+		t.Fatalf("failed to create memory dir: %v", err)
+	}
+
+	// Initialize repository
+	repo, err := memory.NewDefaultRepository(memoryDir)
+	if err != nil {
+		t.Fatalf("failed to create repository: %v", err)
+	}
+	defer repo.Close()
+
+	// Create a test plan and task
+	testPlan := &task.Plan{
+		ID:     "test-plan-001",
+		Goal:   "Test policy enforcement",
+		Status: task.PlanStatusActive,
+	}
+	if err := repo.CreatePlan(testPlan); err != nil {
+		t.Fatalf("failed to create plan: %v", err)
+	}
+
+	testTask := &task.Task{
+		ID:          "test-task-001",
+		PlanID:      testPlan.ID,
+		Title:       "Test task",
+		Description: "A test task for policy enforcement",
+		Status:      task.StatusInProgress,
+		Priority:    50,
+	}
+	if err := repo.CreateTask(testTask); err != nil {
+		t.Fatalf("failed to create task: %v", err)
+	}
+
+	// Change to temp directory so policy engine finds .taskwing/policies
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to change to temp dir: %v", err)
+	}
+	defer os.Chdir(oldWd)
+
+	// Create TaskApp
+	appCtx := &Context{
+		Repo:   repo,
+		LLMCfg: llm.Config{},
+	}
+	taskApp := NewTaskApp(appCtx)
+
+	tests := []struct {
+		name          string
+		filesModified []string
+		expectSuccess bool
+		expectMessage string
+	}{
+		{
+			name:          "allowed_files_should_pass",
+			filesModified: []string{"main.go", "README.md"},
+			expectSuccess: true,
+		},
+		{
+			name:          "env_file_should_be_blocked",
+			filesModified: []string{"main.go", ".env"},
+			expectSuccess: false,
+			expectMessage: "BLOCKED: Environment file",
+		},
+		{
+			name:          "env_local_should_be_blocked",
+			filesModified: []string{".env.local"},
+			expectSuccess: false,
+			expectMessage: "BLOCKED: Environment file",
+		},
+		{
+			name:          "governance_md_should_be_blocked",
+			filesModified: []string{"GOVERNANCE.md"},
+			expectSuccess: false,
+			expectMessage: "BLOCKED: GOVERNANCE.md is a protected file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a new task for each test case
+			taskID := "task-" + tt.name
+			newTask := &task.Task{
+				ID:          taskID,
+				PlanID:      testPlan.ID,
+				Title:       "Test: " + tt.name,
+				Description: "Test task",
+				Status:      task.StatusInProgress,
+				Priority:    50,
+			}
+			if err := repo.CreateTask(newTask); err != nil {
+				t.Fatalf("failed to create task: %v", err)
+			}
+
+			// Attempt to complete the task
+			result, err := taskApp.Complete(context.Background(), TaskCompleteOptions{
+				TaskID:        taskID,
+				Summary:       "Test completion",
+				FilesModified: tt.filesModified,
+			})
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result.Success != tt.expectSuccess {
+				t.Errorf("expected Success=%v, got %v. Message: %s", tt.expectSuccess, result.Success, result.Message)
+			}
+
+			if !tt.expectSuccess && tt.expectMessage != "" {
+				if result.Message == "" || !contains(result.Message, tt.expectMessage) {
+					t.Errorf("expected message to contain %q, got %q", tt.expectMessage, result.Message)
+				}
+			}
+
+			// Verify task status in database
+			taskFromDB, err := repo.GetTask(taskID)
+			if err != nil {
+				t.Fatalf("failed to get task: %v", err)
+			}
+
+			if tt.expectSuccess {
+				if taskFromDB.Status != task.StatusCompleted {
+					t.Errorf("expected task status %s, got %s", task.StatusCompleted, taskFromDB.Status)
+				}
+			} else {
+				if taskFromDB.Status != task.StatusInProgress {
+					t.Errorf("expected task status %s (unchanged), got %s", task.StatusInProgress, taskFromDB.Status)
+				}
+			}
+		})
+	}
+}
+
+// contains checks if s contains substr (case-sensitive).
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -650,6 +650,14 @@ func handleTaskComplete(ctx context.Context, repo *memory.Repository, params Tas
 		}, nil
 	}
 
+	// Check for policy violations (task not completed successfully)
+	if !result.Success {
+		return &TaskToolResult{
+			Action:  "complete",
+			Content: FormatTaskCompletionBlocked(result),
+		}, nil
+	}
+
 	return &TaskToolResult{
 		Action:  "complete",
 		Content: FormatTask(result),

--- a/internal/mcp/presenter.go
+++ b/internal/mcp/presenter.go
@@ -157,17 +157,17 @@ func FormatTaskCompletionBlocked(result *app.TaskResult) string {
 		sb.WriteString(fmt.Sprintf("**Status**: %s (unchanged)\n\n", result.Task.Status))
 	}
 
-	// Reason/Message - format as violations if it contains the policy violation pattern
-	if result.Message != "" {
-		if strings.Contains(result.Message, "Policy violations") {
-			sb.WriteString("### Policy Violations\n\n")
-			sb.WriteString("The following policy rules blocked task completion:\n\n")
-			// The message already contains formatted violations from TaskApp.Complete
-			sb.WriteString(result.Message)
-		} else {
-			sb.WriteString("### Reason\n\n")
-			sb.WriteString(result.Message)
+	// Reason/Message - use structured PolicyViolation field for reliable detection
+	if result.PolicyViolation && len(result.PolicyErrors) > 0 {
+		sb.WriteString("### Policy Violations\n\n")
+		sb.WriteString("The following policy rules blocked task completion:\n\n")
+		for i, err := range result.PolicyErrors {
+			sb.WriteString(fmt.Sprintf("%d. %s\n", i+1, err))
 		}
+		sb.WriteString("\n")
+	} else if result.Message != "" {
+		sb.WriteString("### Reason\n\n")
+		sb.WriteString(result.Message)
 		sb.WriteString("\n\n")
 	}
 

--- a/internal/mcp/presenter.go
+++ b/internal/mcp/presenter.go
@@ -138,6 +138,48 @@ func FormatTask(result *app.TaskResult) string {
 	return strings.TrimSpace(sb.String())
 }
 
+// FormatTaskCompletionBlocked formats a blocked task completion (e.g., policy violations) into Markdown.
+// This provides AI agents with clear, actionable information about why completion was blocked.
+func FormatTaskCompletionBlocked(result *app.TaskResult) string {
+	if result == nil {
+		return FormatError("No task result available.")
+	}
+
+	var sb strings.Builder
+
+	// Error header
+	sb.WriteString("## ❌ Task Completion Blocked\n\n")
+
+	// Task info if available
+	if result.Task != nil {
+		sb.WriteString(fmt.Sprintf("**Task**: %s\n", result.Task.Title))
+		sb.WriteString(fmt.Sprintf("**ID**: `%s`\n", result.Task.ID))
+		sb.WriteString(fmt.Sprintf("**Status**: %s (unchanged)\n\n", result.Task.Status))
+	}
+
+	// Reason/Message - format as violations if it contains the policy violation pattern
+	if result.Message != "" {
+		if strings.Contains(result.Message, "Policy violations") {
+			sb.WriteString("### Policy Violations\n\n")
+			sb.WriteString("The following policy rules blocked task completion:\n\n")
+			// The message already contains formatted violations from TaskApp.Complete
+			sb.WriteString(result.Message)
+		} else {
+			sb.WriteString("### Reason\n\n")
+			sb.WriteString(result.Message)
+		}
+		sb.WriteString("\n\n")
+	}
+
+	// Next steps hint
+	sb.WriteString("### Next Steps\n\n")
+	sb.WriteString("1. Review the violations above\n")
+	sb.WriteString("2. Remove or modify the blocked files from your changes\n")
+	sb.WriteString("3. Retry task completion with `task_complete`\n")
+
+	return strings.TrimSpace(sb.String())
+}
+
 // FormatPlan converts a Plan into concise Markdown.
 func FormatPlan(plan *task.Plan) string {
 	if plan == nil {


### PR DESCRIPTION
## Summary

Implement automatic policy enforcement during task completion

## Completed Tasks

- [x] Define OPA Input Structures for Policy Evaluation
  - Added OPA policy input conversion helpers to internal/app/task.go. Created three functions: TaskToPolicyInput (converts task.Task to policy.TaskInput), PlanToPolicyInput (converts task.Plan to policy.PlanInput), and BuildPolicyInput (constructs complete PolicyInput from both). The existing structures in internal/policy/models.go (TaskInput, PlanInput, PolicyInput) already match the specification requirements. All tests pass.
- [x] Inject PolicyEnforcer into TaskApp.Complete
  - Injected PolicyEnforcer into TaskApp.Complete method. The enforcement chain now runs BEFORE repo.CompleteTask(): 1) Get plan early for policy input, 2) Create task object with files_modified, 3) Create PolicyEngine from .taskwing/policies/, 4) Create PolicyEvaluatorAdapter and PolicyEnforcer, 5) Call Enforce() - if violations detected, return error and keep task in_progress. Removed duplicate workDir and plan retrieval. All tests pass.
- [x] Implement Policy Violation Error Handling
  - Enhanced policy violation error handling in TaskApp.Complete. Violations are now formatted as a numbered list with clear messaging: 'Policy violations blocked task completion:\n 1. violation\n 2. violation\n Task remains in_progress. Fix the violations and retry.' Error handling prioritizes: 1) policy evaluation errors, 2) formatted violation list, 3) fallback message. Database write is never called on policy failure. All tests pass.
- [x] Standardize MCP Violation Formatting
  - Added FormatTaskCompletionBlocked() function to presenter.go that formats policy violations in Markdown with: 1) Error header, 2) Task info (title, ID, status unchanged), 3) Policy violations section with formatted message, 4) Next steps guidance. Updated handleTaskComplete in handlers.go to check result.Success and route to the new formatter when blocked. All MCP tests pass.
- [x] Create Default Policy Directory and Integration Test
  - Created integration test TestTaskComplete_PolicyEnforcement in internal/app/task_policy_test.go. Test covers: 1) allowed files pass through, 2) .env files blocked, 3) .env.local blocked, 4) GOVERNANCE.md blocked. Test creates temp directory with test policy, initializes repository, creates plan/tasks, and verifies both result.Success and database task status. The .taskwing/policies/ directory already exists with default.rego from earlier 'taskwing policy init'. All 4 test cases pass.

---
*Generated by TaskWing*
