### PR TITLE
feat(bootstrap): interactive repo selection for multi-repo workspaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,32 +315,26 @@ TaskWing helps turn a goal into executed tasks with persistent context across AI
 ### Supported Models
 
 <!-- TASKWING_PROVIDERS_START -->
-
 [![OpenAI](https://img.shields.io/badge/OpenAI-412991?logo=openai&logoColor=white)](https://platform.openai.com/)
 [![Anthropic](https://img.shields.io/badge/Anthropic-191919?logo=anthropic&logoColor=white)](https://www.anthropic.com/)
 [![Google Gemini](https://img.shields.io/badge/Google_Gemini-4285F4?logo=google&logoColor=white)](https://ai.google.dev/)
 [![AWS Bedrock](https://img.shields.io/badge/AWS_Bedrock-OpenAI--Compatible_Beta-FF9900?logo=amazonaws&logoColor=white)](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-chat-completions.html)
 [![Ollama](https://img.shields.io/badge/Ollama-Local-000000?logo=ollama&logoColor=white)](https://ollama.com/)
-
 <!-- TASKWING_PROVIDERS_END -->
 
 ### Works With
 
 <!-- TASKWING_TOOLS_START -->
-
 [![Claude Code](https://img.shields.io/badge/Claude_Code-191919?logo=anthropic&logoColor=white)](https://www.anthropic.com/claude-code)
 [![OpenAI Codex](https://img.shields.io/badge/OpenAI_Codex-412991?logo=openai&logoColor=white)](https://developers.openai.com/codex)
 [![Cursor](https://img.shields.io/badge/Cursor-111111?logo=cursor&logoColor=white)](https://cursor.com/)
 [![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-181717?logo=githubcopilot&logoColor=white)](https://github.com/features/copilot)
 [![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-4285F4?logo=google&logoColor=white)](https://github.com/google-gemini/gemini-cli)
 [![OpenCode](https://img.shields.io/badge/OpenCode-000000?logo=opencode&logoColor=white)](https://opencode.ai/)
-
 <!-- TASKWING_TOOLS_END -->
 
 <!-- TASKWING_LEGAL_START -->
-
 Brand names and logos are trademarks of their respective owners; usage here indicates compatibility, not endorsement.
-
 <!-- TASKWING_LEGAL_END -->
 
 ### Slash Commands
@@ -358,7 +352,6 @@ Brand names and logos are trademarks of their respective owners; usage here indi
 ### Core Commands
 
 <!-- TASKWING_COMMANDS_START -->
-
 - `taskwing bootstrap`
 - `taskwing goal "<goal>"`
 - `taskwing ask "<query>"`
@@ -374,16 +367,14 @@ Brand names and logos are trademarks of their respective owners; usage here indi
 ### MCP Tools (Canonical Contract)
 
 <!-- TASKWING_MCP_TOOLS_START -->
-
-| Tool       | Description                                                                         |
-| ---------- | ----------------------------------------------------------------------------------- |
-| `ask`      | Search project knowledge (decisions, patterns, constraints)                         |
-| `task`     | Unified task lifecycle (`next`, `current`, `start`, `complete`)                     |
-| `plan`     | Plan management (`clarify`, `decompose`, `expand`, `generate`, `finalize`, `audit`) |
-| `code`     | Code intelligence (`find`, `search`, `explain`, `callers`, `impact`, `simplify`)    |
-| `debug`    | Diagnose issues systematically with AI-powered analysis                             |
-| `remember` | Store knowledge in project memory                                                   |
-
+| Tool | Description |
+|------|-------------|
+| `ask` | Search project knowledge (decisions, patterns, constraints) |
+| `task` | Unified task lifecycle (`next`, `current`, `start`, `complete`) |
+| `plan` | Plan management (`clarify`, `decompose`, `expand`, `generate`, `finalize`, `audit`) |
+| `code` | Code intelligence (`find`, `search`, `explain`, `callers`, `impact`, `simplify`) |
+| `debug` | Diagnose issues systematically with AI-powered analysis |
+| `remember` | Store knowledge in project memory |
 <!-- TASKWING_MCP_TOOLS_END -->
 
 ### Autonomous Task Execution (Hooks)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -194,32 +194,26 @@ TaskWing helps turn a goal into executed tasks with persistent context across AI
 ### Supported Models
 
 <!-- TASKWING_PROVIDERS_START -->
-
 [![OpenAI](https://img.shields.io/badge/OpenAI-412991?logo=openai&logoColor=white)](https://platform.openai.com/)
 [![Anthropic](https://img.shields.io/badge/Anthropic-191919?logo=anthropic&logoColor=white)](https://www.anthropic.com/)
 [![Google Gemini](https://img.shields.io/badge/Google_Gemini-4285F4?logo=google&logoColor=white)](https://ai.google.dev/)
 [![AWS Bedrock](https://img.shields.io/badge/AWS_Bedrock-OpenAI--Compatible_Beta-FF9900?logo=amazonaws&logoColor=white)](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-chat-completions.html)
 [![Ollama](https://img.shields.io/badge/Ollama-Local-000000?logo=ollama&logoColor=white)](https://ollama.com/)
-
 <!-- TASKWING_PROVIDERS_END -->
 
 ### Works With
 
 <!-- TASKWING_TOOLS_START -->
-
 [![Claude Code](https://img.shields.io/badge/Claude_Code-191919?logo=anthropic&logoColor=white)](https://www.anthropic.com/claude-code)
 [![OpenAI Codex](https://img.shields.io/badge/OpenAI_Codex-412991?logo=openai&logoColor=white)](https://developers.openai.com/codex)
 [![Cursor](https://img.shields.io/badge/Cursor-111111?logo=cursor&logoColor=white)](https://cursor.com/)
 [![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-181717?logo=githubcopilot&logoColor=white)](https://github.com/features/copilot)
 [![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-4285F4?logo=google&logoColor=white)](https://github.com/google-gemini/gemini-cli)
 [![OpenCode](https://img.shields.io/badge/OpenCode-000000?logo=opencode&logoColor=white)](https://opencode.ai/)
-
 <!-- TASKWING_TOOLS_END -->
 
 <!-- TASKWING_LEGAL_START -->
-
 Brand names and logos are trademarks of their respective owners; usage here indicates compatibility, not endorsement.
-
 <!-- TASKWING_LEGAL_END -->
 
 ### Slash Commands
@@ -237,7 +231,6 @@ Brand names and logos are trademarks of their respective owners; usage here indi
 ### Core Commands
 
 <!-- TASKWING_COMMANDS_START -->
-
 - `taskwing bootstrap`
 - `taskwing goal "<goal>"`
 - `taskwing ask "<query>"`
@@ -253,16 +246,14 @@ Brand names and logos are trademarks of their respective owners; usage here indi
 ### MCP Tools (Canonical Contract)
 
 <!-- TASKWING_MCP_TOOLS_START -->
-
-| Tool       | Description                                                                         |
-| ---------- | ----------------------------------------------------------------------------------- |
-| `ask`      | Search project knowledge (decisions, patterns, constraints)                         |
-| `task`     | Unified task lifecycle (`next`, `current`, `start`, `complete`)                     |
-| `plan`     | Plan management (`clarify`, `decompose`, `expand`, `generate`, `finalize`, `audit`) |
-| `code`     | Code intelligence (`find`, `search`, `explain`, `callers`, `impact`, `simplify`)    |
-| `debug`    | Diagnose issues systematically with AI-powered analysis                             |
-| `remember` | Store knowledge in project memory                                                   |
-
+| Tool | Description |
+|------|-------------|
+| `ask` | Search project knowledge (decisions, patterns, constraints) |
+| `task` | Unified task lifecycle (`next`, `current`, `start`, `complete`) |
+| `plan` | Plan management (`clarify`, `decompose`, `expand`, `generate`, `finalize`, `audit`) |
+| `code` | Code intelligence (`find`, `search`, `explain`, `callers`, `impact`, `simplify`) |
+| `debug` | Diagnose issues systematically with AI-powered analysis |
+| `remember` | Store knowledge in project memory |
 <!-- TASKWING_MCP_TOOLS_END -->
 
 ### Autonomous Task Execution (Hooks)

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -195,6 +196,22 @@ func runBootstrap(cmd *cobra.Command, args []string) error {
 	// Initialize Service
 	svc := bootstrap.NewService(cwd, llmCfg)
 
+	// Prompt for repo selection in multi-repo workspaces.
+	// This must happen before the action loop because ActionInitProject may not
+	// be in the plan (e.g., ModeRun), but ActionLLMAnalyze still needs SelectedRepos.
+	if plan.RequiresRepoSelection && slices.Contains(plan.Actions, bootstrap.ActionLLMAnalyze) {
+		if ui.IsInteractive() {
+			fmt.Println()
+			fmt.Printf("📦 Found %d repositories\n\n", len(plan.DetectedRepos))
+			plan.SelectedRepos = promptRepoSelection(plan.DetectedRepos)
+		} else {
+			plan.SelectedRepos = plan.DetectedRepos
+			if !flags.Quiet {
+				fmt.Printf("📦 Non-interactive mode: bootstrapping all %d repositories\n", len(plan.DetectedRepos))
+			}
+		}
+	}
+
 	// Execute actions in order
 	for _, action := range plan.Actions {
 		if err := executeAction(cmd.Context(), action, svc, cwd, flags, plan, llmCfg); err != nil {
@@ -250,7 +267,7 @@ func executeAction(ctx context.Context, action bootstrap.Action, svc *bootstrap.
 		return executeExtractMetadata(ctx, svc, flags)
 
 	case bootstrap.ActionLLMAnalyze:
-		return executeLLMAnalyze(ctx, svc, cwd, flags, llmCfg)
+		return executeLLMAnalyze(ctx, svc, cwd, flags, llmCfg, plan)
 
 	default:
 		return fmt.Errorf("unknown action: %s", action)
@@ -442,7 +459,7 @@ func executeExtractMetadata(ctx context.Context, svc *bootstrap.Service, flags b
 }
 
 // executeLLMAnalyze runs LLM-powered deep analysis.
-func executeLLMAnalyze(ctx context.Context, svc *bootstrap.Service, cwd string, flags bootstrap.Flags, llmCfg llm.Config) error {
+func executeLLMAnalyze(ctx context.Context, svc *bootstrap.Service, cwd string, flags bootstrap.Flags, llmCfg llm.Config, plan *bootstrap.Plan) error {
 	// Detect workspace type
 	ws, err := project.DetectWorkspace(cwd)
 	if err != nil {
@@ -451,6 +468,10 @@ func executeLLMAnalyze(ctx context.Context, svc *bootstrap.Service, cwd string, 
 
 	// Handle multi-repo workspaces
 	if ws.IsMultiRepo() {
+		// Scope to user-selected repos
+		if len(plan.SelectedRepos) > 0 {
+			ws.Services = plan.SelectedRepos
+		}
 		return runMultiRepoBootstrap(ctx, svc, ws, flags.Preview)
 	}
 
@@ -650,7 +671,7 @@ func runMultiRepoBootstrap(ctx context.Context, svc *bootstrap.Service, ws *proj
 	fmt.Println("")
 	ui.RenderPageHeader("TaskWing Multi-Repo Bootstrap", fmt.Sprintf("Workspace: %s | Services: %d", ws.Name, ws.ServiceCount()))
 
-	fmt.Printf("📦 Detected %d services. Running parallel analysis...\n", ws.ServiceCount())
+	fmt.Printf("📦 Analyzing %d services. Running parallel analysis...\n", ws.ServiceCount())
 
 	findings, relationships, errs, err := svc.RunMultiRepoAnalysis(ctx, ws)
 	if err != nil {
@@ -672,6 +693,21 @@ func runMultiRepoBootstrap(ctx context.Context, svc *bootstrap.Service, ws *proj
 	}
 
 	return svc.IngestDirectly(ctx, findings, relationships, viper.GetBool("quiet"))
+}
+
+// promptRepoSelection prompts the user to select which repositories to bootstrap.
+// Returns all repos on error or cancel to avoid silent no-op.
+func promptRepoSelection(repos []string) []string {
+	selected, err := ui.PromptRepoSelection(repos)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "⚠️  Repo selection failed: %v — analyzing all repositories\n", err)
+		return repos
+	}
+	if selected == nil {
+		fmt.Println("⚠️  Selection cancelled — analyzing all repositories")
+		return repos
+	}
+	return selected
 }
 
 // installMCPServers handles the binary installation calls (kept in CLI layer)

--- a/docs/PRODUCT_VISION.md
+++ b/docs/PRODUCT_VISION.md
@@ -13,32 +13,26 @@ We don't just store tasks. We generate context-aware development plans by analyz
 ### Supported Models
 
 <!-- TASKWING_PROVIDERS_START -->
-
 [![OpenAI](https://img.shields.io/badge/OpenAI-412991?logo=openai&logoColor=white)](https://platform.openai.com/)
 [![Anthropic](https://img.shields.io/badge/Anthropic-191919?logo=anthropic&logoColor=white)](https://www.anthropic.com/)
 [![Google Gemini](https://img.shields.io/badge/Google_Gemini-4285F4?logo=google&logoColor=white)](https://ai.google.dev/)
 [![AWS Bedrock](https://img.shields.io/badge/AWS_Bedrock-OpenAI--Compatible_Beta-FF9900?logo=amazonaws&logoColor=white)](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-chat-completions.html)
 [![Ollama](https://img.shields.io/badge/Ollama-Local-000000?logo=ollama&logoColor=white)](https://ollama.com/)
-
 <!-- TASKWING_PROVIDERS_END -->
 
 ### Works With
 
 <!-- TASKWING_TOOLS_START -->
-
 [![Claude Code](https://img.shields.io/badge/Claude_Code-191919?logo=anthropic&logoColor=white)](https://www.anthropic.com/claude-code)
 [![OpenAI Codex](https://img.shields.io/badge/OpenAI_Codex-412991?logo=openai&logoColor=white)](https://developers.openai.com/codex)
 [![Cursor](https://img.shields.io/badge/Cursor-111111?logo=cursor&logoColor=white)](https://cursor.com/)
 [![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-181717?logo=githubcopilot&logoColor=white)](https://github.com/features/copilot)
 [![Gemini CLI](https://img.shields.io/badge/Gemini_CLI-4285F4?logo=google&logoColor=white)](https://github.com/google-gemini/gemini-cli)
 [![OpenCode](https://img.shields.io/badge/OpenCode-000000?logo=opencode&logoColor=white)](https://opencode.ai/)
-
 <!-- TASKWING_TOOLS_END -->
 
 <!-- TASKWING_LEGAL_START -->
-
 Brand names and logos are trademarks of their respective owners; usage here indicates compatibility, not endorsement.
-
 <!-- TASKWING_LEGAL_END -->
 
 ## Architecture
@@ -71,7 +65,6 @@ Brand names and logos are trademarks of their respective owners; usage here indi
 ## Core Commands
 
 <!-- TASKWING_COMMANDS_START -->
-
 - `taskwing bootstrap`
 - `taskwing goal "<goal>"`
 - `taskwing ask "<query>"`
@@ -87,16 +80,14 @@ Brand names and logos are trademarks of their respective owners; usage here indi
 ## MCP Tools
 
 <!-- TASKWING_MCP_TOOLS_START -->
-
-| Tool       | Description                                                                         |
-| ---------- | ----------------------------------------------------------------------------------- |
-| `ask`      | Search project knowledge (decisions, patterns, constraints)                         |
-| `task`     | Unified task lifecycle (`next`, `current`, `start`, `complete`)                     |
-| `plan`     | Plan management (`clarify`, `decompose`, `expand`, `generate`, `finalize`, `audit`) |
-| `code`     | Code intelligence (`find`, `search`, `explain`, `callers`, `impact`, `simplify`)    |
-| `debug`    | Diagnose issues systematically with AI-powered analysis                             |
-| `remember` | Store knowledge in project memory                                                   |
-
+| Tool | Description |
+|------|-------------|
+| `ask` | Search project knowledge (decisions, patterns, constraints) |
+| `task` | Unified task lifecycle (`next`, `current`, `start`, `complete`) |
+| `plan` | Plan management (`clarify`, `decompose`, `expand`, `generate`, `finalize`, `audit`) |
+| `code` | Code intelligence (`find`, `search`, `explain`, `callers`, `impact`, `simplify`) |
+| `debug` | Diagnose issues systematically with AI-powered analysis |
+| `remember` | Store knowledge in project memory |
 <!-- TASKWING_MCP_TOOLS_END -->
 
 ## Success Metrics

--- a/internal/bootstrap/planner.go
+++ b/internal/bootstrap/planner.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"sort"
 	"strings"
+
+	"github.com/josephgoksu/TaskWing/internal/project"
 )
 
 // BootstrapMode represents the high-level mode of operation.
@@ -97,6 +99,9 @@ type Snapshot struct {
 	// Code stats
 	FileCount      int  `json:"file_count"`
 	IsLargeProject bool `json:"is_large_project"` // > threshold
+
+	// Workspace
+	Workspace *project.WorkspaceInfo `json:"workspace,omitempty"`
 }
 
 // Flags captures all CLI flags in a structured way.
@@ -139,6 +144,11 @@ type Plan struct {
 
 	// Execution state (populated during execution, not planning)
 	SelectedAIs []string `json:"selected_ais,omitempty"` // User's actual AI selection
+
+	// Multi-repo workspace selection
+	DetectedRepos       []string `json:"detected_repos,omitempty"`
+	SelectedRepos       []string `json:"selected_repos,omitempty"`
+	RequiresRepoSelection bool   `json:"requires_repo_selection"`
 
 	// Error state
 	Error        error  `json:"-"`
@@ -218,6 +228,11 @@ func ProbeEnvironment(basePath string) (*Snapshot, error) {
 	// Count source files (for large project detection)
 	snap.FileCount = countSourceFiles(basePath)
 	snap.IsLargeProject = snap.FileCount > 5000
+
+	// Detect workspace type (single, monorepo, multi-repo)
+	if ws, err := project.DetectWorkspace(basePath); err == nil {
+		snap.Workspace = ws
+	}
 
 	return snap, nil
 }
@@ -310,6 +325,12 @@ func DecidePlan(snap *Snapshot, flags Flags) *Plan {
 		// Fallback - shouldn't happen but be explicit
 		plan.Mode = ModeRun
 		plan.DetectedState = "Existing setup"
+	}
+
+	// Detect multi-repo workspace and set repo selection fields
+	if snap.Workspace != nil && snap.Workspace.Type == project.WorkspaceTypeMultiRepo {
+		plan.DetectedRepos = snap.Workspace.Services
+		plan.RequiresRepoSelection = true
 	}
 
 	// Now determine actions based on mode and flags
@@ -787,6 +808,10 @@ func FormatPlanSummary(plan *Plan, quiet bool) string {
 	// Detailed output (not in quiet mode)
 	if !quiet {
 		fmt.Fprintf(&sb, "\nDetected: %s\n", plan.DetectedState)
+
+		if plan.RequiresRepoSelection && len(plan.DetectedRepos) > 0 {
+			fmt.Fprintf(&sb, "Workspace: Multi-repo (%d repositories detected)\n", len(plan.DetectedRepos))
+		}
 
 		if len(plan.Actions) > 0 {
 			sb.WriteString("\nActions:\n")

--- a/internal/project/detect.go
+++ b/internal/project/detect.go
@@ -3,6 +3,9 @@ package project
 import (
 	"errors"
 	"path/filepath"
+	"strings"
+
+	"github.com/spf13/afero"
 )
 
 // ErrNoProjectFound is returned when no project root could be detected.
@@ -87,7 +90,7 @@ func (d *detector) Detect(startPath string) (*Context, error) {
 					RootPath:   current,
 					MarkerType: MarkerTaskWing,
 					GitRoot:    gitRoot,
-					IsMonorepo: gitRoot != "" && gitRoot != current,
+					IsMonorepo: gitRoot != "" && (gitRoot != current || d.hasNestedProjects(current)),
 				}, nil
 			}
 		}
@@ -127,7 +130,7 @@ func (d *detector) Detect(startPath string) (*Context, error) {
 			RootPath:   gitRoot,
 			MarkerType: MarkerGit,
 			GitRoot:    gitRoot,
-			IsMonorepo: false,
+			IsMonorepo: d.hasNestedProjects(gitRoot),
 		}, nil
 	}
 
@@ -188,4 +191,124 @@ func (d *detector) findGitRoot(startPath string) string {
 		current = parent
 	}
 	return ""
+}
+
+// nestedProjectMarkers are the files that indicate a directory is a project.
+// Shared with workspace.go's isProjectDir for consistency.
+var nestedProjectMarkers = []string{
+	"package.json",
+	"go.mod",
+	"Cargo.toml",
+	"pom.xml",
+	"pyproject.toml",
+	"build.gradle",
+	"requirements.txt",
+	"Dockerfile",
+}
+
+// alwaysSkipDirs is a minimal safety-net for directories that should never be
+// considered as project subdirectories, even when .gitignore is absent or unreadable.
+// These are generated/vendored directories that commonly contain nested manifests.
+var alwaysSkipDirs = map[string]bool{
+	"node_modules": true,
+	"vendor":       true,
+	"__pycache__":  true,
+}
+
+// hasNestedProjects checks if a directory contains multiple subdirectories
+// that look like independent projects (each with their own manifest file).
+// This detects monorepo roots where RootPath == GitRoot but the directory
+// structure clearly contains multiple services/packages.
+//
+// Directories are skipped if they match .gitignore patterns, the alwaysSkipDirs
+// safety net, or are hidden (dot-prefixed).
+//
+// Requires at least 2 nested project directories to return true,
+// reducing false positives for repos with a single nested manifest.
+func (d *detector) hasNestedProjects(dir string) bool {
+	ignored := d.loadGitignore(dir)
+
+	entries, err := afero.ReadDir(d.fs, dir)
+	if err != nil {
+		return false
+	}
+
+	count := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, ".") || alwaysSkipDirs[name] || ignored[name] {
+			continue
+		}
+		if d.isProjectDir(filepath.Join(dir, name)) {
+			count++
+			if count >= 2 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// loadGitignore reads .gitignore from dir and returns a set of directory names
+// that should be ignored. It handles the common gitignore patterns:
+//   - Simple names: "dist", "build"
+//   - Directory markers: "dist/", "build/"
+//   - Root-anchored: "/dist", "/build/"
+//   - Comments (#) and blank lines are skipped
+//   - Negation patterns (!) are skipped (conservative: don't un-ignore)
+//
+// Only simple name patterns are matched (no wildcards, no path separators
+// mid-pattern). This covers the vast majority of real-world gitignore entries
+// for top-level directories.
+func (d *detector) loadGitignore(dir string) map[string]bool {
+	ignored := make(map[string]bool)
+
+	data, err := afero.ReadFile(d.fs, filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		return ignored
+	}
+
+	for _, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(raw)
+
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Skip negation patterns (conservative: don't un-ignore anything)
+		if strings.HasPrefix(line, "!") {
+			continue
+		}
+
+		// Strip root anchor (leading /)
+		line = strings.TrimPrefix(line, "/")
+		// Strip directory indicator (trailing /)
+		line = strings.TrimSuffix(line, "/")
+
+		// Only match simple names (no path separators, no glob wildcards).
+		// Patterns like "logs/*.log" or "src/generated" are path-based and
+		// don't apply to top-level directory matching.
+		if strings.ContainsAny(line, "/*?[") {
+			continue
+		}
+
+		if line != "" {
+			ignored[line] = true
+		}
+	}
+
+	return ignored
+}
+
+// isProjectDir checks if a directory contains any project marker file.
+func (d *detector) isProjectDir(dir string) bool {
+	for _, marker := range nestedProjectMarkers {
+		if exists, _ := d.exists(filepath.Join(dir, marker)); exists {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/project/detect_test.go
+++ b/internal/project/detect_test.go
@@ -1,0 +1,421 @@
+package project
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+)
+
+// setupFS creates an in-memory filesystem with the given paths.
+// Paths ending with "/" are created as directories, others as files.
+// Paths with content use the format "path=content".
+func setupFS(paths []string) afero.Fs {
+	fs := afero.NewMemMapFs()
+	for _, p := range paths {
+		if p[len(p)-1] == '/' {
+			_ = fs.MkdirAll(p, 0755)
+		} else {
+			_ = afero.WriteFile(fs, p, []byte(""), 0644)
+		}
+	}
+	return fs
+}
+
+
+func TestDetect_MonorepoRootWithGitOnly(t *testing.T) {
+	// Polyglot monorepo: .git at root, multiple subdirs with manifests, no root manifest
+	// This is the markwise-app scenario.
+	fs := setupFS([]string{
+		"/monorepo/.git/",
+		"/monorepo/web/package.json",
+		"/monorepo/backend/go.mod",
+		"/monorepo/admin/package.json",
+		"/monorepo/docs/",
+	})
+
+	d := NewDetector(fs)
+	ctx, err := d.Detect("/monorepo")
+	if err != nil {
+		t.Fatalf("Detect() error: %v", err)
+	}
+
+	if ctx.RootPath != "/monorepo" {
+		t.Errorf("RootPath = %q, want /monorepo", ctx.RootPath)
+	}
+	if ctx.GitRoot != "/monorepo" {
+		t.Errorf("GitRoot = %q, want /monorepo", ctx.GitRoot)
+	}
+	if ctx.MarkerType != MarkerGit {
+		t.Errorf("MarkerType = %v, want MarkerGit", ctx.MarkerType)
+	}
+	if !ctx.IsMonorepo {
+		t.Error("IsMonorepo = false, want true (multiple nested projects detected)")
+	}
+}
+
+func TestDetect_MonorepoRootWithTaskWing(t *testing.T) {
+	// After bootstrap: .taskwing + .git at root, multiple subdirs with manifests
+	fs := setupFS([]string{
+		"/monorepo/.git/",
+		"/monorepo/.taskwing/",
+		"/monorepo/web/package.json",
+		"/monorepo/backend/go.mod",
+		"/monorepo/chrome-ext/package.json",
+	})
+
+	d := NewDetector(fs)
+	ctx, err := d.Detect("/monorepo")
+	if err != nil {
+		t.Fatalf("Detect() error: %v", err)
+	}
+
+	if ctx.MarkerType != MarkerTaskWing {
+		t.Errorf("MarkerType = %v, want MarkerTaskWing", ctx.MarkerType)
+	}
+	if !ctx.IsMonorepo {
+		t.Error("IsMonorepo = false, want true (.taskwing at root with nested projects)")
+	}
+}
+
+func TestDetect_MonorepoSubdirectory(t *testing.T) {
+	// Running from a subdirectory of a monorepo (existing behavior)
+	fs := setupFS([]string{
+		"/monorepo/.git/",
+		"/monorepo/backend/go.mod",
+		"/monorepo/web/package.json",
+	})
+
+	d := NewDetector(fs)
+	ctx, err := d.Detect("/monorepo/backend")
+	if err != nil {
+		t.Fatalf("Detect() error: %v", err)
+	}
+
+	if ctx.RootPath != "/monorepo/backend" {
+		t.Errorf("RootPath = %q, want /monorepo/backend", ctx.RootPath)
+	}
+	if ctx.GitRoot != "/monorepo" {
+		t.Errorf("GitRoot = %q, want /monorepo", ctx.GitRoot)
+	}
+	if !ctx.IsMonorepo {
+		t.Error("IsMonorepo = false, want true (RootPath != GitRoot)")
+	}
+}
+
+func TestDetect_SingleRepoWithGitOnly(t *testing.T) {
+	// Single project: .git at root, no nested project directories
+	fs := setupFS([]string{
+		"/myproject/.git/",
+		"/myproject/src/",
+		"/myproject/README.md",
+	})
+
+	d := NewDetector(fs)
+	ctx, err := d.Detect("/myproject")
+	if err != nil {
+		t.Fatalf("Detect() error: %v", err)
+	}
+
+	if ctx.IsMonorepo {
+		t.Error("IsMonorepo = true, want false (no nested projects)")
+	}
+}
+
+func TestDetect_SingleRepoWithManifest(t *testing.T) {
+	// Standard single project: .git + package.json at root
+	fs := setupFS([]string{
+		"/myapp/.git/",
+		"/myapp/package.json",
+		"/myapp/src/",
+	})
+
+	d := NewDetector(fs)
+	ctx, err := d.Detect("/myapp")
+	if err != nil {
+		t.Fatalf("Detect() error: %v", err)
+	}
+
+	if ctx.MarkerType != MarkerPackageJSON {
+		t.Errorf("MarkerType = %v, want MarkerPackageJSON", ctx.MarkerType)
+	}
+	if ctx.IsMonorepo {
+		t.Error("IsMonorepo = true, want false (single repo with root manifest)")
+	}
+}
+
+func TestDetect_SingleNestedProjectNotMonorepo(t *testing.T) {
+	// Git root with only ONE nested project dir - should NOT be detected as monorepo.
+	// Threshold is 2+ nested projects.
+	fs := setupFS([]string{
+		"/repo/.git/",
+		"/repo/backend/go.mod",
+		"/repo/docs/",
+	})
+
+	d := NewDetector(fs)
+	ctx, err := d.Detect("/repo")
+	if err != nil {
+		t.Fatalf("Detect() error: %v", err)
+	}
+
+	if ctx.IsMonorepo {
+		t.Error("IsMonorepo = true, want false (only 1 nested project, threshold is 2)")
+	}
+}
+
+func TestDetect_SkipsNodeModulesAndVendor(t *testing.T) {
+	// Ensure node_modules and vendor are always skipped (safety net)
+	fs := setupFS([]string{
+		"/repo/.git/",
+		"/repo/node_modules/some-pkg/package.json",
+		"/repo/vendor/dep/go.mod",
+		"/repo/web/package.json",
+	})
+
+	d := NewDetector(fs)
+	ctx, err := d.Detect("/repo")
+	if err != nil {
+		t.Fatalf("Detect() error: %v", err)
+	}
+
+	if ctx.IsMonorepo {
+		t.Error("IsMonorepo = true, want false (node_modules and vendor should be skipped)")
+	}
+}
+
+func TestDetect_GitignoreSkipsDirs(t *testing.T) {
+	// .gitignore lists "dist" and "build" — those should not count as projects
+	fs := afero.NewMemMapFs()
+	_ = fs.MkdirAll("/repo/.git", 0755)
+	_ = afero.WriteFile(fs, "/repo/.gitignore", []byte("dist\nbuild/\n"), 0644)
+	// dist and build have manifests but are gitignored
+	_ = afero.WriteFile(fs, "/repo/dist/package.json", []byte(""), 0644)
+	_ = afero.WriteFile(fs, "/repo/build/package.json", []byte(""), 0644)
+	// Only one real project dir
+	_ = afero.WriteFile(fs, "/repo/web/package.json", []byte(""), 0644)
+
+	d := NewDetector(fs)
+	ctx, err := d.Detect("/repo")
+	if err != nil {
+		t.Fatalf("Detect() error: %v", err)
+	}
+
+	if ctx.IsMonorepo {
+		t.Error("IsMonorepo = true, want false (dist and build are gitignored, only 1 real project)")
+	}
+}
+
+func TestDetect_GitignoreDoesNotAffectRealProjects(t *testing.T) {
+	// .gitignore lists build artifacts, but real project dirs are not ignored
+	fs := afero.NewMemMapFs()
+	_ = fs.MkdirAll("/repo/.git", 0755)
+	_ = afero.WriteFile(fs, "/repo/.gitignore", []byte("dist\ncoverage\n.next\n"), 0644)
+	_ = afero.WriteFile(fs, "/repo/web/package.json", []byte(""), 0644)
+	_ = afero.WriteFile(fs, "/repo/api/go.mod", []byte(""), 0644)
+	_ = afero.WriteFile(fs, "/repo/admin/package.json", []byte(""), 0644)
+
+	d := NewDetector(fs)
+	ctx, err := d.Detect("/repo")
+	if err != nil {
+		t.Fatalf("Detect() error: %v", err)
+	}
+
+	if !ctx.IsMonorepo {
+		t.Error("IsMonorepo = false, want true (3 real project dirs, gitignore only affects build artifacts)")
+	}
+}
+
+func TestHasNestedProjects(t *testing.T) {
+	tests := []struct {
+		name  string
+		paths []string
+		dir   string
+		want  bool
+	}{
+		{
+			name: "two nested projects",
+			paths: []string{
+				"/root/web/package.json",
+				"/root/api/go.mod",
+			},
+			dir:  "/root",
+			want: true,
+		},
+		{
+			name: "three nested projects (polyglot)",
+			paths: []string{
+				"/root/frontend/package.json",
+				"/root/backend/go.mod",
+				"/root/ml/pyproject.toml",
+			},
+			dir:  "/root",
+			want: true,
+		},
+		{
+			name: "one nested project",
+			paths: []string{
+				"/root/app/package.json",
+				"/root/docs/",
+			},
+			dir:  "/root",
+			want: false,
+		},
+		{
+			name: "no nested projects",
+			paths: []string{
+				"/root/src/",
+				"/root/README.md",
+			},
+			dir:  "/root",
+			want: false,
+		},
+		{
+			name: "always-skip dirs not counted",
+			paths: []string{
+				"/root/node_modules/pkg/package.json",
+				"/root/vendor/lib/go.mod",
+				"/root/web/package.json",
+			},
+			dir:  "/root",
+			want: false,
+		},
+		{
+			name: "hidden dirs not counted",
+			paths: []string{
+				"/root/.cache/tool/package.json",
+				"/root/.internal/svc/go.mod",
+			},
+			dir:  "/root",
+			want: false,
+		},
+		{
+			name: "dockerfile counts as project marker",
+			paths: []string{
+				"/root/svc-a/Dockerfile",
+				"/root/svc-b/Dockerfile",
+			},
+			dir:  "/root",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := setupFS(tt.paths)
+			det := &detector{fs: fs}
+			got := det.hasNestedProjects(tt.dir)
+			if got != tt.want {
+				t.Errorf("hasNestedProjects(%q) = %v, want %v", tt.dir, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadGitignore(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    map[string]bool
+	}{
+		{
+			name:    "simple names",
+			content: "dist\nbuild\ncoverage\n",
+			want:    map[string]bool{"dist": true, "build": true, "coverage": true},
+		},
+		{
+			name:    "directory markers stripped",
+			content: "dist/\nbuild/\ntarget/\n",
+			want:    map[string]bool{"dist": true, "build": true, "target": true},
+		},
+		{
+			name:    "root-anchored patterns stripped",
+			content: "/dist\n/build/\n/out\n",
+			want:    map[string]bool{"dist": true, "build": true, "out": true},
+		},
+		{
+			name:    "comments and blank lines skipped",
+			content: "# Build output\ndist\n\n# Coverage\ncoverage\n\n",
+			want:    map[string]bool{"dist": true, "coverage": true},
+		},
+		{
+			name:    "negation patterns skipped",
+			content: "dist\n!dist/important\nbuild\n",
+			want:    map[string]bool{"dist": true, "build": true},
+		},
+		{
+			name:    "glob patterns skipped",
+			content: "*.log\ndist\nlogs/*.txt\nbuild\n",
+			want:    map[string]bool{"dist": true, "build": true},
+		},
+		{
+			name:    "path patterns with separators skipped",
+			content: "src/generated\ndist\nfoo/bar/baz\n",
+			want:    map[string]bool{"dist": true},
+		},
+		{
+			name:    "whitespace trimmed",
+			content: "  dist  \n  build  \n",
+			want:    map[string]bool{"dist": true, "build": true},
+		},
+		{
+			name:    "empty file",
+			content: "",
+			want:    map[string]bool{},
+		},
+		{
+			name:    "realistic gitignore",
+			content: "# Dependencies\nnode_modules\n\n# Build\ndist/\nbuild/\n.next/\n\n# Coverage\ncoverage/\n\n# Env\n.env\n.env.local\n\n# Logs\n*.log\n",
+			want:    map[string]bool{"node_modules": true, "dist": true, "build": true, ".next": true, "coverage": true, ".env": true, ".env.local": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := afero.NewMemMapFs()
+			_ = afero.WriteFile(fs, "/project/.gitignore", []byte(tt.content), 0644)
+
+			det := &detector{fs: fs}
+			got := det.loadGitignore("/project")
+
+			if len(got) != len(tt.want) {
+				t.Errorf("loadGitignore() returned %d entries, want %d\n  got:  %v\n  want: %v", len(got), len(tt.want), got, tt.want)
+				return
+			}
+			for k := range tt.want {
+				if !got[k] {
+					t.Errorf("loadGitignore() missing key %q", k)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadGitignore_NoFile(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	det := &detector{fs: fs}
+	got := det.loadGitignore("/nonexistent")
+
+	if len(got) != 0 {
+		t.Errorf("loadGitignore() returned %d entries for missing file, want 0", len(got))
+	}
+}
+
+func TestDetect_GitignoreWithAnchoredPattern(t *testing.T) {
+	// /dist in gitignore should match top-level "dist" dir
+	fs := afero.NewMemMapFs()
+	_ = fs.MkdirAll("/repo/.git", 0755)
+	_ = afero.WriteFile(fs, "/repo/.gitignore", []byte("/dist\n/out\n"), 0644)
+	_ = afero.WriteFile(fs, "/repo/dist/package.json", []byte(""), 0644)
+	_ = afero.WriteFile(fs, "/repo/out/package.json", []byte(""), 0644)
+	_ = afero.WriteFile(fs, "/repo/web/package.json", []byte(""), 0644)
+
+	d := NewDetector(fs)
+	ctx, err := d.Detect("/repo")
+	if err != nil {
+		t.Fatalf("Detect() error: %v", err)
+	}
+
+	if ctx.IsMonorepo {
+		t.Error("IsMonorepo = true, want false (dist and out are gitignored via /dist and /out)")
+	}
+}

--- a/internal/ui/repo_select.go
+++ b/internal/ui/repo_select.go
@@ -1,0 +1,157 @@
+package ui
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// PromptRepoSelection displays a multi-select list for choosing repositories to bootstrap.
+// All repos are pre-selected by default (user deselects what they don't want).
+// preSelected is optional; if empty, all repos are pre-selected.
+func PromptRepoSelection(repos []string, preSelected ...string) ([]string, error) {
+	selected := make(map[string]bool)
+	if len(preSelected) > 0 {
+		for _, r := range preSelected {
+			selected[r] = true
+		}
+	} else {
+		// Default: all repos selected
+		for _, r := range repos {
+			selected[r] = true
+		}
+	}
+
+	m := repoSelectModel{
+		choices:  repos,
+		cursor:   0,
+		selected: selected,
+	}
+
+	p := tea.NewProgram(m)
+	finalModel, err := p.Run()
+	if err != nil {
+		return nil, fmt.Errorf("error running repo selection: %w", err)
+	}
+
+	result := finalModel.(repoSelectModel)
+	if result.quit {
+		return nil, nil
+	}
+
+	// Build list of selected repos in original order
+	var resultSelected []string
+	for _, r := range repos {
+		if result.selected[r] {
+			resultSelected = append(resultSelected, r)
+		}
+	}
+	return resultSelected, nil
+}
+
+// repoSelectModel is the Bubble Tea model for repository multi-selection.
+type repoSelectModel struct {
+	choices  []string
+	cursor   int
+	selected map[string]bool
+	quit     bool
+}
+
+func (m repoSelectModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m repoSelectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q", "esc":
+			m.quit = true
+			return m, tea.Quit
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case "down", "j":
+			if m.cursor < len(m.choices)-1 {
+				m.cursor++
+			}
+		case " ":
+			// Toggle selection
+			choice := m.choices[m.cursor]
+			m.selected[choice] = !m.selected[choice]
+		case "enter":
+			// Confirm selection
+			hasSelection := false
+			for _, v := range m.selected {
+				if v {
+					hasSelection = true
+					break
+				}
+			}
+			if hasSelection {
+				return m, tea.Quit
+			}
+			// No selection — treat as cancel
+			m.quit = true
+			return m, tea.Quit
+		case "s":
+			// Skip repo selection (use all)
+			for _, c := range m.choices {
+				m.selected[c] = true
+			}
+			return m, tea.Quit
+		case "a":
+			// Select all
+			for _, c := range m.choices {
+				m.selected[c] = true
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m repoSelectModel) View() string {
+	checkedStyle := lipgloss.NewStyle().Foreground(ColorSelected)
+
+	var sb strings.Builder
+	sb.WriteString("\n")
+	sb.WriteString(StyleSelectTitle.Render("Choose repositories to bootstrap:"))
+	sb.WriteString("\n\n")
+
+	for i, choice := range m.choices {
+		displayName := filepath.Base(choice)
+
+		cursor := "  "
+		checkbox := "[ ]"
+		style := StyleSelectNormal
+
+		if m.selected[choice] {
+			checkbox = checkedStyle.Render("[✓]")
+		}
+
+		if m.cursor == i {
+			cursor = "▶ "
+			style = StyleSelectActive
+		}
+		fmt.Fprintf(&sb, "%s%s %s\n", cursor, checkbox, style.Render(displayName))
+	}
+
+	// Count selected
+	count := 0
+	for _, v := range m.selected {
+		if v {
+			count++
+		}
+	}
+
+	sb.WriteString("\n")
+	sb.WriteString(StyleSelectDim.Render(fmt.Sprintf("%d/%d selected", count, len(m.choices))))
+	sb.WriteString("\n")
+	sb.WriteString(StyleSelectDim.Render("↑/↓ navigate • space toggle • a all • enter confirm • s skip (all) • esc cancel"))
+	sb.WriteString("\n")
+	return sb.String()
+}

--- a/internal/utils/json.go
+++ b/internal/utils/json.go
@@ -249,9 +249,13 @@ func sanitizeControlChars(input string) string {
 			continue
 		}
 
-		if c == '\\' && inString {
-			result.WriteByte(c)
-			escaped = true
+		if c == '\\' {
+			if inString {
+				result.WriteByte(c)
+				escaped = true
+			}
+			// Outside strings, backslashes are invalid JSON — strip them.
+			// Common in LLM output: literal \n between values, regex snippets, etc.
 			continue
 		}
 


### PR DESCRIPTION
## Summary

- Adds a multi-select TUI for choosing which repos to bootstrap in multi-repo workspaces
- Workspace detection moved to plan phase so preview/plan summary shows detected repos
- Repo selection runs before the action loop (works in ModeRun, not just ModeFirstTime)
- Only prompts when LLM analysis is in the plan; non-interactive mode defaults to all repos

## Files

- `internal/bootstrap/planner.go` — Workspace field on Snapshot, repo selection fields on Plan, early detection in ProbeEnvironment
- `internal/ui/repo_select.go` — New multi-select TUI (same pattern as AI selection)
- `cmd/bootstrap.go` — Wire selection into runBootstrap, scope executeLLMAnalyze to selected repos

## Test plan

- [ ] `go build ./...` passes
- [ ] `make test-quick` passes
- [ ] From multi-repo dir: `taskwing bootstrap --preview` shows detected repos in summary
- [ ] From multi-repo dir: `taskwing bootstrap` shows repo selection after AI selection
- [ ] From single-repo dir: no repo selection shown
- [ ] Non-interactive: defaults to all repos without prompting