### PR TITLE
fix(task): improve task lifecycle UX with 6 targeted fixes

### DIFF
--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -227,16 +227,16 @@ func runContinueCheck(maxTasks, maxMinutes int) error {
 		})
 	}
 
-	// Open repository
+	// Open repository — graceful degradation on failure
 	repo, err := openRepo()
 	if err != nil {
 		if isMissingProjectMemoryError(err) {
 			return outputHookResponse(HookResponse{
-				Reason: "No project memory found. Run 'taskwing bootstrap' to initialize project memory.",
+				Reason: "No project memory found. Run 'taskwing bootstrap' to initialize project memory, or use /tw-next to continue manually.",
 			})
 		}
 		return outputHookResponse(HookResponse{
-			Reason: fmt.Sprintf("Failed to open repository: %v", err),
+			Reason: fmt.Sprintf("Could not open repository: %v. Use /tw-next to continue manually.", err),
 		})
 	}
 	defer func() { _ = repo.Close() }()
@@ -332,7 +332,7 @@ func runContinueCheck(maxTasks, maxMinutes int) error {
 	blockDecision := "block"
 	return outputHookResponse(HookResponse{
 		Decision: &blockDecision,
-		Reason:   fmt.Sprintf("Continue to task %d/%d: %s\n\n%s", session.TasksCompleted+1, len(activePlan.Tasks), nextTask.Title, contextStr),
+		Reason:   fmt.Sprintf("Continue to task %d/%d: %s\n\n%s\n\nIf auto-continue fails, use /tw-next to proceed manually.", session.TasksCompleted+1, len(activePlan.Tasks), nextTask.Title, contextStr),
 	})
 }
 

--- a/cmd/mcp_server.go
+++ b/cmd/mcp_server.go
@@ -224,18 +224,27 @@ func runMCPServer(ctx context.Context) error {
 - current: Get current in-progress task for session
 - start: Claim a specific task by ID
 - complete: Mark task as completed with summary
+- skip: Skip a task that's irrelevant or overlapping (use summary for reason)
 
 REQUIRED FIELDS BY ACTION:
-- next: session_id (optional when called via MCP session, required otherwise)
-- current: session_id (optional when called via MCP session, required otherwise)
-- start: task_id (required), session_id (optional when called via MCP session)
-- complete: task_id (required)`,
+- next: session_id (auto-inferred from hook session if omitted)
+- current: session_id (auto-inferred from hook session if omitted)
+- start: task_id (required), session_id (auto-inferred from hook session if omitted)
+- complete: task_id (required)
+- skip: task_id (required), summary (optional skip reason)`,
 	}
 	mcpsdk.AddTool(server, taskTool, func(ctx context.Context, session *mcpsdk.ServerSession, params *mcpsdk.CallToolParamsFor[mcppresenter.TaskToolParams]) (*mcpsdk.CallToolResultFor[any], error) {
 		defaultSessionID := ""
 		if session != nil {
 			if sid := strings.TrimSpace(session.ID()); sid != "" {
 				defaultSessionID = sid
+			}
+		}
+		// Fallback: infer session_id from hook_session.json when MCP transport
+		// doesn't provide one (Claude Code stdio never does).
+		if defaultSessionID == "" {
+			if hs, hsErr := loadHookSession(); hsErr == nil && hs.SessionID != "" {
+				defaultSessionID = hs.SessionID
 			}
 		}
 		result, err := mcppresenter.HandleTaskTool(ctx, repo, params.Arguments, defaultSessionID)

--- a/internal/app/plan.go
+++ b/internal/app/plan.go
@@ -76,17 +76,7 @@ type GenerateOptions struct {
 	ClarifySessionID string // Required: clarify session that reached ready state
 	EnrichedGoal     string // Fully clarified specification
 	Save             bool   // Whether to persist plan/tasks to DB
-	ExplicitTasks    []ExplicitTask // If provided, use these instead of LLM generation
-}
-
-// ExplicitTask is a caller-provided task definition that bypasses LLM generation.
-type ExplicitTask struct {
-	Title              string
-	Description        string
-	AcceptanceCriteria []string
-	ValidationSteps    []string
-	Priority           int
-	Complexity         string
+	ExplicitTasks    []task.TaskInput // If provided, use these instead of LLM generation
 }
 
 // AuditResult contains the result of plan auditing.

--- a/internal/app/plan.go
+++ b/internal/app/plan.go
@@ -76,6 +76,17 @@ type GenerateOptions struct {
 	ClarifySessionID string // Required: clarify session that reached ready state
 	EnrichedGoal     string // Fully clarified specification
 	Save             bool   // Whether to persist plan/tasks to DB
+	ExplicitTasks    []ExplicitTask // If provided, use these instead of LLM generation
+}
+
+// ExplicitTask is a caller-provided task definition that bypasses LLM generation.
+type ExplicitTask struct {
+	Title              string
+	Description        string
+	AcceptanceCriteria []string
+	ValidationSteps    []string
+	Priority           int
+	Complexity         string
 }
 
 // AuditResult contains the result of plan auditing.
@@ -575,42 +586,69 @@ func (a *PlanApp) Generate(ctx context.Context, opts GenerateOptions) (*Generate
 		}
 	}
 
-	// Create and run PlanningAgent
-	planningAgent := a.PlannerFactory(llmCfg)
-	defer func() { _ = planningAgent.Close() }()
+	// If caller provided explicit tasks, use them directly (skip LLM generation)
+	var tasks []task.Task
+	if len(opts.ExplicitTasks) > 0 {
+		for i, et := range opts.ExplicitTasks {
+			priority := et.Priority
+			if priority == 0 {
+				priority = (i + 1) * 10 // auto-assign sequential priority
+			}
+			complexity := et.Complexity
+			if complexity == "" {
+				complexity = "medium"
+			}
+			t := task.Task{
+				ID:                 fmt.Sprintf("task-%s", uuid.New().String()[:8]),
+				Title:              et.Title,
+				Description:        et.Description,
+				AcceptanceCriteria: et.AcceptanceCriteria,
+				ValidationSteps:    et.ValidationSteps,
+				Priority:           priority,
+				Complexity:         complexity,
+				Status:             task.StatusPending,
+			}
+			t.EnrichAIFields()
+			tasks = append(tasks, t)
+		}
+	} else {
+		// Create and run PlanningAgent
+		planningAgent := a.PlannerFactory(llmCfg)
+		defer func() { _ = planningAgent.Close() }()
 
-	input := core.Input{
-		ExistingContext: map[string]any{
-			"goal":          opts.Goal,
-			"enriched_goal": opts.EnrichedGoal,
-			"context":       contextStr,
-		},
-	}
+		input := core.Input{
+			ExistingContext: map[string]any{
+				"goal":          opts.Goal,
+				"enriched_goal": opts.EnrichedGoal,
+				"context":       contextStr,
+			},
+		}
 
-	output, err := planningAgent.Run(ctx, input)
-	if err != nil {
-		return &GenerateResult{
-			Success: false,
-			Message: fmt.Sprintf("Planning agent failed: %v", err),
-		}, nil
-	}
-	if output.Error != nil {
-		return &GenerateResult{
-			Success: false,
-			Message: fmt.Sprintf("Planning agent error: %v", output.Error),
-		}, nil
-	}
+		output, err := planningAgent.Run(ctx, input)
+		if err != nil {
+			return &GenerateResult{
+				Success: false,
+				Message: fmt.Sprintf("Planning agent failed: %v", err),
+			}, nil
+		}
+		if output.Error != nil {
+			return &GenerateResult{
+				Success: false,
+				Message: fmt.Sprintf("Planning agent error: %v", output.Error),
+			}, nil
+		}
 
-	// Parse tasks from output
-	if len(output.Findings) == 0 {
-		return &GenerateResult{
-			Success: false,
-			Message: "No findings from planning agent",
-		}, nil
-	}
+		// Parse tasks from output
+		if len(output.Findings) == 0 {
+			return &GenerateResult{
+				Success: false,
+				Message: "No findings from planning agent",
+			}, nil
+		}
 
-	finding := output.Findings[0]
-	tasks := a.parseTasksFromMetadata(ctx, finding.Metadata)
+		finding := output.Findings[0]
+		tasks = a.parseTasksFromMetadata(ctx, finding.Metadata)
+	}
 
 	if len(tasks) == 0 {
 		return &GenerateResult{

--- a/internal/config/prompts.go
+++ b/internal/config/prompts.go
@@ -525,6 +525,7 @@ Your job is to decompose this goal into a sequential list of actionable executio
     - If a caching constraint exists, high-volume endpoints MUST implement caching
     - Never suggest code that violates documented constraints
 5.  **Verification**: For each task, define clear acceptance criteria and a validation command (e.g., "go test ./...").
+6.  **No Overlap**: Each task must be a distinct, non-overlapping unit of work. Do NOT create separate tasks for testing and implementation of the same feature — combine them. If multiple tasks would modify the same files or address the same problem from different angles, merge them into one task. When a caller provides an explicit tasks array, use those tasks directly instead of generating new ones.
 
 **Input Context:**
 - Enriched Goal: {{.Goal}}
@@ -560,6 +561,7 @@ Your job is to break this down into 3-5 logical phases that can be reviewed and 
 3.  **Right-Sized**: Each phase should expand into 2-4 detailed tasks (not too granular, not too vague).
 4.  **Clear Done State**: Each phase should have a clear "done" condition that can be verified.
 5.  **Context Aware**: Use the provided Knowledge Graph Context to align with existing patterns and constraints.
+6.  **No Overlap**: Phases must not overlap in scope. Each phase should own a distinct set of files/concerns. Do not split related work (e.g., implementation + testing of the same feature) across phases.
 
 **Input Context:**
 - Enriched Goal: {{.EnrichedGoal}}
@@ -606,6 +608,7 @@ Your job is to generate 2-4 atomic tasks that fully accomplish this phase.
 3.  **Complete Coverage**: The tasks together must fully accomplish the phase's stated goal.
 4.  **Context Aware**: Use the Knowledge Graph Context to respect existing patterns and constraints.
 5.  **Verifiable**: Each task must have clear acceptance criteria and validation steps.
+6.  **No Overlap**: Tasks must not duplicate effort. Do NOT create separate tasks for "write tests" and "implement feature" for the same change — combine them into one task. If two tasks would modify the same files, merge them. Check against tasks already generated for other phases to avoid cross-phase overlap.
 
 **Input Context:**
 - Phase Title: {{.PhaseTitle}}

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -519,7 +519,7 @@ func HandleTaskTool(ctx context.Context, repo *memory.Repository, params TaskToo
 	if !params.Action.IsValid() {
 		return &TaskToolResult{
 			Action: string(params.Action),
-			Error:  fmt.Sprintf("invalid action %q, must be one of: next, current, start, complete", params.Action),
+			Error:  fmt.Sprintf("invalid action %q, must be one of: next, current, start, complete, skip", params.Action),
 		}, nil
 	}
 
@@ -532,6 +532,8 @@ func HandleTaskTool(ctx context.Context, repo *memory.Repository, params TaskToo
 		return handleTaskStart(ctx, repo, params, defaultSessionID)
 	case TaskActionComplete:
 		return handleTaskComplete(ctx, repo, params)
+	case TaskActionSkip:
+		return handleTaskSkip(ctx, repo, params)
 	default:
 		return &TaskToolResult{
 			Action: string(params.Action),
@@ -706,6 +708,43 @@ func handleTaskComplete(ctx context.Context, repo *memory.Repository, params Tas
 	}, nil
 }
 
+// handleTaskSkip implements the 'skip' action - skip a task that's irrelevant or overlapping.
+func handleTaskSkip(_ context.Context, repo *memory.Repository, params TaskToolParams) (*TaskToolResult, error) {
+	taskID := strings.TrimSpace(params.TaskID)
+	if taskID == "" {
+		return &TaskToolResult{
+			Action: "skip",
+			Error:  "task_id is required for skip action",
+		}, nil
+	}
+
+	reason := strings.TrimSpace(params.Summary)
+	if reason == "" {
+		reason = "Skipped by user"
+	}
+
+	if err := repo.SkipTask(taskID, reason); err != nil {
+		return &TaskToolResult{
+			Action: "skip",
+			Error:  err.Error(),
+		}, nil
+	}
+
+	// Fetch the updated task to show confirmation
+	t, err := repo.GetTask(taskID)
+	if err != nil {
+		return &TaskToolResult{
+			Action:  "skip",
+			Content: fmt.Sprintf("Task %s skipped. Reason: %s", taskID, reason),
+		}, nil
+	}
+
+	return &TaskToolResult{
+		Action:  "skip",
+		Content: fmt.Sprintf("## Task Skipped\n\n**%s** (`%s`)\n\n**Reason**: %s\n\nUse `task action=next` to get the next pending task.", t.Title, t.ID, reason),
+	}, nil
+}
+
 // === Plan Tool Handler ===
 
 // PlanToolResult represents the response from the unified plan tool.
@@ -854,11 +893,25 @@ func handlePlanGenerate(ctx context.Context, repo *memory.Repository, params Pla
 	appCtx := app.NewContextForRole(repo, llm.RoleBootstrap)
 	planApp := app.NewPlanApp(appCtx)
 
+	// Convert explicit tasks from params if provided
+	var explicitTasks []app.ExplicitTask
+	for _, t := range params.Tasks {
+		explicitTasks = append(explicitTasks, app.ExplicitTask{
+			Title:              t.Title,
+			Description:        t.Description,
+			AcceptanceCriteria: t.AcceptanceCriteria,
+			ValidationSteps:    t.ValidationSteps,
+			Priority:           t.Priority,
+			Complexity:         t.Complexity,
+		})
+	}
+
 	result, err := planApp.Generate(ctx, app.GenerateOptions{
 		Goal:             goal,
 		ClarifySessionID: clarifySessionID,
 		EnrichedGoal:     enrichedGoal,
 		Save:             save,
+		ExplicitTasks:    explicitTasks,
 	})
 	if err != nil {
 		return &PlanToolResult{

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -893,25 +893,12 @@ func handlePlanGenerate(ctx context.Context, repo *memory.Repository, params Pla
 	appCtx := app.NewContextForRole(repo, llm.RoleBootstrap)
 	planApp := app.NewPlanApp(appCtx)
 
-	// Convert explicit tasks from params if provided
-	var explicitTasks []app.ExplicitTask
-	for _, t := range params.Tasks {
-		explicitTasks = append(explicitTasks, app.ExplicitTask{
-			Title:              t.Title,
-			Description:        t.Description,
-			AcceptanceCriteria: t.AcceptanceCriteria,
-			ValidationSteps:    t.ValidationSteps,
-			Priority:           t.Priority,
-			Complexity:         t.Complexity,
-		})
-	}
-
 	result, err := planApp.Generate(ctx, app.GenerateOptions{
 		Goal:             goal,
 		ClarifySessionID: clarifySessionID,
 		EnrichedGoal:     enrichedGoal,
 		Save:             save,
-		ExplicitTasks:    explicitTasks,
+		ExplicitTasks:    params.Tasks,
 	})
 	if err != nil {
 		return &PlanToolResult{

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -4,6 +4,8 @@ package mcp
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/josephgoksu/TaskWing/internal/task"
 )
 
 // === Action Constants ===
@@ -249,14 +251,8 @@ type PhaseInput struct {
 }
 
 // TaskInput represents user-provided task data for interactive mode.
-type TaskInput struct {
-	Title              string   `json:"title"`
-	Description        string   `json:"description,omitempty"`
-	AcceptanceCriteria []string `json:"acceptance_criteria,omitempty"`
-	ValidationSteps    []string `json:"validation_steps,omitempty"`
-	Priority           int      `json:"priority,omitempty"`
-	Complexity         string   `json:"complexity,omitempty"`
-}
+// TaskInput is an alias for task.TaskInput — shared struct for explicit task definitions.
+type TaskInput = task.TaskInput
 
 // ClarifyAnswerInput is a structured answer to a clarification question.
 type ClarifyAnswerInput struct {

--- a/internal/mcp/types.go
+++ b/internal/mcp/types.go
@@ -42,17 +42,18 @@ const (
 	TaskActionCurrent  TaskAction = "current"
 	TaskActionStart    TaskAction = "start"
 	TaskActionComplete TaskAction = "complete"
+	TaskActionSkip     TaskAction = "skip"
 )
 
 // ValidTaskActions returns all valid task actions.
 func ValidTaskActions() []TaskAction {
-	return []TaskAction{TaskActionNext, TaskActionCurrent, TaskActionStart, TaskActionComplete}
+	return []TaskAction{TaskActionNext, TaskActionCurrent, TaskActionStart, TaskActionComplete, TaskActionSkip}
 }
 
 // IsValid checks if the action is a valid task action.
 func (a TaskAction) IsValid() bool {
 	switch a {
-	case TaskActionNext, TaskActionCurrent, TaskActionStart, TaskActionComplete:
+	case TaskActionNext, TaskActionCurrent, TaskActionStart, TaskActionComplete, TaskActionSkip:
 		return true
 	}
 	return false

--- a/internal/memory/repository_tasks.go
+++ b/internal/memory/repository_tasks.go
@@ -83,6 +83,11 @@ func (r *Repository) CompleteTask(taskID, summary string, filesModified []string
 	return r.db.CompleteTask(taskID, summary, filesModified)
 }
 
+// SkipTask marks a task as skipped with an optional reason.
+func (r *Repository) SkipTask(taskID, reason string) error {
+	return r.db.SkipTask(taskID, reason)
+}
+
 // GetActivePlan returns the currently active plan.
 func (r *Repository) GetActivePlan() (*task.Plan, error) {
 	return r.db.GetActivePlan()

--- a/internal/memory/task_store.go
+++ b/internal/memory/task_store.go
@@ -924,11 +924,11 @@ func (s *SQLiteStore) GetNextTask(planID string) (*task.Task, error) {
 		AND NOT EXISTS (
 			SELECT 1 FROM task_dependencies td
 			JOIN tasks dep ON dep.id = td.depends_on
-			WHERE td.task_id = t.id AND dep.status != ?
+			WHERE td.task_id = t.id AND dep.status NOT IN (?, ?)
 		)
 		ORDER BY t.priority ASC, t.created_at ASC
 		LIMIT 1
-	`, planID, task.StatusPending, task.StatusCompleted)
+	`, planID, task.StatusPending, task.StatusCompleted, task.StatusSkipped)
 
 	t, err := scanTaskRow(row)
 	if err == sql.ErrNoRows {
@@ -1121,6 +1121,41 @@ func (s *SQLiteStore) CompleteTask(taskID, summary string, filesModified []strin
 			return fmt.Errorf("task not found: %s", taskID)
 		}
 		return fmt.Errorf("cannot complete task: current status is %s (must be in_progress)", status)
+	}
+
+	return nil
+}
+
+// SkipTask marks a task as skipped with an optional reason.
+// Allows skipping from pending or in_progress status.
+func (s *SQLiteStore) SkipTask(taskID, reason string) error {
+	if taskID == "" {
+		return fmt.Errorf("task id is required")
+	}
+
+	nowStr := time.Now().UTC().Format(time.RFC3339)
+
+	res, err := s.db.Exec(`
+		UPDATE tasks
+		SET status = ?, completion_summary = ?, completed_at = ?, updated_at = ?
+		WHERE id = ? AND status IN (?, ?)
+	`, task.StatusSkipped, reason, nowStr, nowStr, taskID, task.StatusPending, task.StatusInProgress)
+
+	if err != nil {
+		return fmt.Errorf("skip task: %w", err)
+	}
+
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("skip task rows affected: %w", err)
+	}
+	if affected == 0 {
+		var status task.TaskStatus
+		err := s.db.QueryRow(`SELECT status FROM tasks WHERE id = ?`, taskID).Scan(&status)
+		if err == sql.ErrNoRows {
+			return fmt.Errorf("task not found: %s", taskID)
+		}
+		return fmt.Errorf("cannot skip task: current status is %s (must be pending or in_progress)", status)
 	}
 
 	return nil

--- a/internal/task/models.go
+++ b/internal/task/models.go
@@ -18,6 +18,7 @@ const (
 	StatusVerifying  TaskStatus = "verifying"   // Work done, running validation
 	StatusCompleted  TaskStatus = "completed"   // Successfully verified
 	StatusFailed     TaskStatus = "failed"      // Execution or verification failed
+	StatusSkipped    TaskStatus = "skipped"     // Skipped by user or agent
 	StatusBlocked    TaskStatus = "blocked"     // Waiting on dependencies
 	StatusReady      TaskStatus = "ready"       // Dependencies met, ready for execution
 )

--- a/internal/task/models.go
+++ b/internal/task/models.go
@@ -23,6 +23,17 @@ const (
 	StatusReady      TaskStatus = "ready"       // Dependencies met, ready for execution
 )
 
+// TaskInput is a caller-provided task definition used to bypass LLM generation.
+// Shared between MCP handlers and the plan app layer.
+type TaskInput struct {
+	Title              string   `json:"title"`
+	Description        string   `json:"description,omitempty"`
+	AcceptanceCriteria []string `json:"acceptance_criteria,omitempty"`
+	ValidationSteps    []string `json:"validation_steps,omitempty"`
+	Priority           int      `json:"priority,omitempty"`
+	Complexity         string   `json:"complexity,omitempty"`
+}
+
 // PhaseStatus represents the lifecycle state of a phase
 type PhaseStatus string
 


### PR DESCRIPTION
## Summary

Addresses 6 task lifecycle UX defects identified during real-world plan execution:

- **session_id auto-inference**: Infer from `hook_session.json` when MCP transport doesn't provide one — eliminates the friction of every `task action=next` failing on first attempt
- **Task skip action**: New `skip` action (pending/in_progress → skipped) with reason tracking, plus skipped tasks treated as resolved in dependency graph
- **Hook resilience**: `continue-check` gracefully degrades with `/tw-next` fallback instead of failing silently when repo can't be opened
- **Explicit tasks passthrough**: `plan action=generate` now respects caller-provided `tasks` array, bypassing LLM generation entirely
- **Anti-overlap prompts**: Planner, decomposer, and expander agents now instructed to merge overlapping tasks instead of splitting implementation/testing
- **StatusSkipped model**: Added `skipped` status to task lifecycle state machine

## Changed files

| File | Change |
|------|--------|
| `cmd/mcp_server.go` | session_id fallback from hook_session.json, skip action docs |
| `cmd/hook.go` | Graceful error handling with `/tw-next` fallback |
| `internal/mcp/types.go` | `TaskActionSkip` enum value |
| `internal/mcp/handlers.go` | `handleTaskSkip` handler, explicit tasks passthrough |
| `internal/memory/task_store.go` | `SkipTask()` method, dependency query fix |
| `internal/memory/repository_tasks.go` | `SkipTask` wrapper |
| `internal/task/models.go` | `StatusSkipped` constant |
| `internal/app/plan.go` | `ExplicitTask` type, early return path |
| `internal/config/prompts.go` | Anti-overlap instructions in 3 agent prompts |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/memory/... ./internal/mcp/... ./internal/task/... ./internal/config/... ./internal/app/...` — 19 tests pass
- [ ] Verify `task action=skip` via MCP with a pending task
- [ ] Verify `task action=next` works without explicit session_id
- [ ] Verify `plan action=generate` with explicit tasks array bypasses LLM
- [ ] Verify hook continue-check outputs `/tw-next` fallback on repo error

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR delivers 6 targeted UX improvements to the task lifecycle: session ID auto-inference from `hook_session.json`, a new `skip` action with dependency-graph awareness, hook graceful degradation with `/tw-next` fallback hints, explicit tasks passthrough for `plan action=generate`, anti-overlap prompt instructions across all three agent prompts, and the `StatusSkipped` model constant.

The core mechanics are correct — the SQL dependency fix (`NOT IN (completed, skipped)`), the `SkipTask` lifecycle implementation, and the session inference fallback all work as intended. However, there are several documentation gaps that create usability friction:

- **Stale struct comment**: `TaskToolParams` struct comment omits the newly added `skip` action, leaving callers without documentation of what it does or what fields it requires.
- **Undocumented dual-use**: `PlanToolParams.Tasks` field is documented only for `expand` but is now silently also consumed by `generate` with entirely different semantics (user edits vs. LLM-bypass), creating a trap for callers who won't know what behavior to expect.
- **DRY violation**: `ExplicitTask` in `internal/app/plan.go` is structurally identical to `TaskInput` in `internal/mcp/types.go` with a manual field-by-field mapping that creates maintenance burden — any future field additions must be made in three places.
- **Stale schema comment**: The inline SQL comment for the `status` column in `sqlite.go` still lists the old set of allowed values and doesn't include `skipped`.
</details>


<h3>Confidence Score: 4/5</h3>

- Safe to merge — no runtime-breaking bugs found; all logic is correct. Issues are documentation drift and a DRY violation in types.
- Score held to 4 (not 5) due to: (1) Stale/incomplete API documentation (`TaskToolParams` struct comment omits `skip` action, `PlanToolParams.Tasks` field silently dual-purposed for two actions with different semantics but only one documented); (2) DRY violation in type design (`ExplicitTask` duplicates `mcp.TaskInput` structure with manual field-by-field mapping). All logic changes are correct: SQL parameter count matches placeholders, `SkipTask` rows-affected guard prevents silent no-ops, session inference is properly nil/empty-guarded, explicit tasks bypass is cleanly isolated.
- internal/mcp/types.go (stale struct comment and undocumented dual-use of Tasks field), internal/app/plan.go (ExplicitTask DRY violation)

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([pending]) -->|task action=start| B([in_progress])
    A -->|task action=skip| E([skipped])
    B -->|task action=complete| C([verifying])
    B -->|task action=skip| E
    C -->|validation pass| D([completed])
    C -->|validation fail| F([failed])

    subgraph Dependency Resolution
        D -->|unblocks dependents| G{GetNextTask}
        E -->|treated as resolved| G
        G -->|NOT IN completed,skipped| H([next pending task])
    end

    subgraph Session ID Inference
        I[MCP tool call] --> J{session.ID available?}
        J -->|yes| K[use transport session ID]
        J -->|no| L{hook_session.json exists?}
        L -->|yes, SessionID != empty| M[use hook session ID]
        L -->|no| N[empty session ID / caller must provide]
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `internal/mcp/types.go`, line 141-152 ([link](https://github.com/josephgoksu/taskwing/blob/cb4e9dbb1740083faeb4fbeb4b747346455eb4c4/internal/mcp/types.go#L141-L152)) 

   The `TaskToolParams` struct comment still lists only `next, current, start, complete` and omits the newly added `skip` action. This leaves callers without documentation of what `skip` does or what fields it requires.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/mcp/types.go
   Line: 141-152

   Comment:
   The `TaskToolParams` struct comment still lists only `next, current, start, complete` and omits the newly added `skip` action. This leaves callers without documentation of what `skip` does or what fields it requires.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fmcp%2Ftypes.go%0ALine%3A%20141-152%0A%0AComment%3A%0AThe%20%60TaskToolParams%60%20struct%20comment%20still%20lists%20only%20%60next%2C%20current%2C%20start%2C%20complete%60%20and%20omits%20the%20newly%20added%20%60skip%60%20action.%20This%20leaves%20callers%20without%20documentation%20of%20what%20%60skip%60%20does%20or%20what%20fields%20it%20requires.%0A%0A%60%60%60suggestion%0A%2F%2F%20TaskToolParams%20defines%20the%20parameters%20for%20the%20unified%20task%20tool.%0A%2F%2F%20Supports%20lifecycle%20actions%3A%20next%2C%20current%2C%20start%2C%20complete%2C%20skip%0A%2F%2F%0A%2F%2F%20Required%20fields%20by%20action%3A%0A%2F%2F%20%20%20-%20next%3A%20session_id%20%28optional%20when%20MCP%20transport%20provides%20session%20identity%29%0A%2F%2F%20%20%20-%20current%3A%20session_id%20%28optional%20when%20MCP%20transport%20provides%20session%20identity%29%0A%2F%2F%20%20%20-%20start%3A%20task_id%2C%20session_id%20%28optional%20when%20MCP%20transport%20provides%20session%20identity%29%0A%2F%2F%20%20%20-%20complete%3A%20task_id%0A%2F%2F%20%20%20-%20skip%3A%20task_id%20%28required%29%2C%20summary%20%28optional%20skip%20reason%29%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=josephgoksu%2Ftaskwing"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix in Claude Code" src="https://img.shields.io/badge/Fix_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>


2. `internal/mcp/types.go`, line 335-337 ([link](https://github.com/josephgoksu/taskwing/blob/cb4e9dbb1740083faeb4fbeb4b747346455eb4c4/internal/mcp/types.go#L335-L337)) 

   `PlanToolParams.Tasks` is now silently used by both `expand` and `generate` actions with completely different semantics, but the documentation only mentions `expand`. This undocumented dual-use creates a trap for callers: if they send `tasks` to `generate` expecting `expand`-style feedback behavior, they'll instead trigger LLM-bypass behavior.

   

   Also update the `PlanToolParams` required-fields comment block to document `tasks` as optional for both actions.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/mcp/types.go
   Line: 335-337

   Comment:
   `PlanToolParams.Tasks` is now silently used by both `expand` and `generate` actions with completely different semantics, but the documentation only mentions `expand`. This undocumented dual-use creates a trap for callers: if they send `tasks` to `generate` expecting `expand`-style feedback behavior, they'll instead trigger LLM-bypass behavior.

   

   Also update the `PlanToolParams` required-fields comment block to document `tasks` as optional for both actions.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fmcp%2Ftypes.go%0ALine%3A%20335-337%0A%0AComment%3A%0A%60PlanToolParams.Tasks%60%20is%20now%20silently%20used%20by%20both%20%60expand%60%20and%20%60generate%60%20actions%20with%20completely%20different%20semantics%2C%20but%20the%20documentation%20only%20mentions%20%60expand%60.%20This%20undocumented%20dual-use%20creates%20a%20trap%20for%20callers%3A%20if%20they%20send%20%60tasks%60%20to%20%60generate%60%20expecting%20%60expand%60-style%20feedback%20behavior%2C%20they'll%20instead%20trigger%20LLM-bypass%20behavior.%0A%0A%60%60%60suggestion%0A%09%2F%2F%20Tasks%20is%20user-provided%20task%20data.%0A%09%2F%2F%20Optional%20for%3A%20expand%20%28allows%20user%20modifications%20to%20proposed%20tasks%29%0A%09%2F%2F%20Optional%20for%3A%20generate%20%28if%20provided%2C%20bypasses%20LLM%20task%20generation%20entirely%29%0A%09Tasks%20%5B%5DTaskInput%20%60json%3A%22tasks%2Comitempty%22%60%0A%60%60%60%0A%0AAlso%20update%20the%20%60PlanToolParams%60%20required-fields%20comment%20block%20to%20document%20%60tasks%60%20as%20optional%20for%20both%20actions.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=josephgoksu%2Ftaskwing"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix in Claude Code" src="https://img.shields.io/badge/Fix_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>


3. `internal/memory/sqlite.go`, line 199 ([link](https://github.com/josephgoksu/taskwing/blob/cb4e9dbb1740083faeb4fbeb4b747346455eb4c4/internal/memory/sqlite.go#L199)) 

   The inline schema comment lists allowed status values but was not updated to include `skipped`.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/memory/sqlite.go
   Line: 199

   Comment:
   The inline schema comment lists allowed status values but was not updated to include `skipped`.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Fmemory%2Fsqlite.go%0ALine%3A%20199%0A%0AComment%3A%0AThe%20inline%20schema%20comment%20lists%20allowed%20status%20values%20but%20was%20not%20updated%20to%20include%20%60skipped%60.%0A%0A%60%60%60suggestion%0A%09%09status%20TEXT%20DEFAULT%20'pending'%2C%20%20%20%20%20--%20pending%2C%20in_progress%2C%20verifying%2C%20completed%2C%20failed%2C%20skipped%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=josephgoksu%2Ftaskwing"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix in Claude Code" src="https://img.shields.io/badge/Fix_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Ainternal%2Fmcp%2Ftypes.go%3A141-152%0AThe%20%60TaskToolParams%60%20struct%20comment%20still%20lists%20only%20%60next%2C%20current%2C%20start%2C%20complete%60%20and%20omits%20the%20newly%20added%20%60skip%60%20action.%20This%20leaves%20callers%20without%20documentation%20of%20what%20%60skip%60%20does%20or%20what%20fields%20it%20requires.%0A%0A%60%60%60suggestion%0A%2F%2F%20TaskToolParams%20defines%20the%20parameters%20for%20the%20unified%20task%20tool.%0A%2F%2F%20Supports%20lifecycle%20actions%3A%20next%2C%20current%2C%20start%2C%20complete%2C%20skip%0A%2F%2F%0A%2F%2F%20Required%20fields%20by%20action%3A%0A%2F%2F%20%20%20-%20next%3A%20session_id%20%28optional%20when%20MCP%20transport%20provides%20session%20identity%29%0A%2F%2F%20%20%20-%20current%3A%20session_id%20%28optional%20when%20MCP%20transport%20provides%20session%20identity%29%0A%2F%2F%20%20%20-%20start%3A%20task_id%2C%20session_id%20%28optional%20when%20MCP%20transport%20provides%20session%20identity%29%0A%2F%2F%20%20%20-%20complete%3A%20task_id%0A%2F%2F%20%20%20-%20skip%3A%20task_id%20%28required%29%2C%20summary%20%28optional%20skip%20reason%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Ainternal%2Fmcp%2Ftypes.go%3A335-337%0A%60PlanToolParams.Tasks%60%20is%20now%20silently%20used%20by%20both%20%60expand%60%20and%20%60generate%60%20actions%20with%20completely%20different%20semantics%2C%20but%20the%20documentation%20only%20mentions%20%60expand%60.%20This%20undocumented%20dual-use%20creates%20a%20trap%20for%20callers%3A%20if%20they%20send%20%60tasks%60%20to%20%60generate%60%20expecting%20%60expand%60-style%20feedback%20behavior%2C%20they'll%20instead%20trigger%20LLM-bypass%20behavior.%0A%0A%60%60%60suggestion%0A%09%2F%2F%20Tasks%20is%20user-provided%20task%20data.%0A%09%2F%2F%20Optional%20for%3A%20expand%20%28allows%20user%20modifications%20to%20proposed%20tasks%29%0A%09%2F%2F%20Optional%20for%3A%20generate%20%28if%20provided%2C%20bypasses%20LLM%20task%20generation%20entirely%29%0A%09Tasks%20%5B%5DTaskInput%20%60json%3A%22tasks%2Comitempty%22%60%0A%60%60%60%0A%0AAlso%20update%20the%20%60PlanToolParams%60%20required-fields%20comment%20block%20to%20document%20%60tasks%60%20as%20optional%20for%20both%20actions.%0A%0A%23%23%23%20Issue%203%20of%204%0Ainternal%2Fapp%2Fplan.go%3A82-90%0A%60ExplicitTask%60%20is%20structurally%20identical%20to%20%60mcp.TaskInput%60%20in%20%60internal%2Fmcp%2Ftypes.go%60%20%28all%20six%20fields%2C%20same%20types%2C%20no%20transformation%29.%20The%20handler%20manually%20maps%20%60TaskInput%20%E2%86%92%20ExplicitTask%60%20field-by-field%20at%20%60handlers.go%60%20lines%20898%E2%80%93907%2C%20creating%20a%20maintenance%20burden%3A%20any%20future%20field%20additions%20must%20be%20made%20in%20three%20places%20%28TaskInput%2C%20ExplicitTask%2C%20and%20the%20mapping%29.%0A%0AConsider%20either%20accepting%20%60%5B%5Dmcp.TaskInput%60%20directly%20in%20%60GenerateOptions%60%20or%20moving%20%60ExplicitTask%60%20to%20a%20shared%20types%20package%20so%20both%20layers%20reference%20the%20same%20type.%20The%20current%20parallel-struct%20pattern%20with%20manual%20mapping%20is%20a%20DRY%20violation.%0A%0A%23%23%23%20Issue%204%20of%204%0Ainternal%2Fmemory%2Fsqlite.go%3A199%0AThe%20inline%20schema%20comment%20lists%20allowed%20status%20values%20but%20was%20not%20updated%20to%20include%20%60skipped%60.%0A%0A%60%60%60suggestion%0A%09%09status%20TEXT%20DEFAULT%20'pending'%2C%20%20%20%20%20--%20pending%2C%20in_progress%2C%20verifying%2C%20completed%2C%20failed%2C%20skipped%0A%60%60%60%0A%0A&repo=josephgoksu%2Ftaskwing"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<sub>Last reviewed commit: cb4e9db</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->