### PR TITLE
feat(ui): enhance color styling with adaptive colors and improve term…

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,24 +78,6 @@ curl -fsSL https://taskwing.app/install.sh | sh
 
 No signup. No account. Works offline. Everything stays local in SQLite.
 
-## Quick Start
-
-```bash
-# 1. Extract your architecture
-cd your-project
-taskwing bootstrap
-# → 22 decisions, 12 patterns, 9 constraints extracted
-
-# 2. Set a goal and generate a plan
-taskwing goal "Add Stripe billing"
-# → Plan decomposed into 5 executable tasks
-
-# 3. Execute with your AI assistant
-/tw-next       # Get next task with full context
-# ...work...
-/tw-done       # Mark complete, advance to next
-```
-
 ## Supported Models
 
 <!-- TASKWING_PROVIDERS_START -->
@@ -120,6 +102,24 @@ taskwing goal "Add Stripe billing"
 <!-- TASKWING_LEGAL_START -->
 Brand names and logos are trademarks of their respective owners; usage here indicates compatibility, not endorsement.
 <!-- TASKWING_LEGAL_END -->
+
+## Quick Start
+
+```bash
+# 1. Extract your architecture
+cd your-project
+taskwing bootstrap
+# → 22 decisions, 12 patterns, 9 constraints extracted
+
+# 2. Set a goal and generate a plan
+taskwing goal "Add Stripe billing"
+# → Plan decomposed into 5 executable tasks
+
+# 3. Execute with your AI assistant
+/tw-next       # Get next task with full context
+# ...work...
+/tw-done       # Mark complete, advance to next
+```
 
 ## MCP Tools
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,25 @@ Your AI tools start every session from zero. They don't know your stack, your pa
 
 **TaskWing fixes this.** One command extracts your architecture into a local database. Every AI session after that just *knows*.
 
+## Why TaskWing?
+
+Your AI assistant reads the same files every session. TaskWing remembers so it doesn't have to.
+
+```
+Without TaskWing              With TaskWing
+─────────────────             ─────────────
+8–12 file reads               1 MCP query
+~25,000 tokens                ~1,500 tokens
+2–3 minutes                   42 seconds
+Zero persistent context       170+ knowledge nodes
+```
+
+**Real session, real numbers** — asked *"What are the bottlenecks in our engineering process?"*:
+- **Without TaskWing:** 8 Glob/Grep searches, 12 file reads, 25,000 tokens, 3 minutes
+- **With TaskWing MCP:** 1 query, 1,500 tokens, 42 seconds — synthesized answer with code references
+
+That's **90% fewer tokens** and **75% faster** time-to-answer.
+
 ## What It Does
 
 | Capability | Description |

--- a/internal/ui/config_menu.go
+++ b/internal/ui/config_menu.go
@@ -194,16 +194,16 @@ func (m configMenuModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 var (
 	configTitleStyle = lipgloss.NewStyle().
 				Bold(true).
-				Foreground(lipgloss.Color("39"))
+				Foreground(lipgloss.AdaptiveColor{Light: "25", Dark: "39"})
 
 	configActiveStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("86"))
+				Foreground(lipgloss.AdaptiveColor{Light: "30", Dark: "86"})
 
 	configDimStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("240"))
+			Foreground(ColorDim)
 
 	configValueStyle = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("229"))
+				Foreground(lipgloss.AdaptiveColor{Light: "136", Dark: "229"})
 )
 
 func (m configMenuModel) View() string {

--- a/internal/ui/context_view.go
+++ b/internal/ui/context_view.go
@@ -42,8 +42,8 @@ func RenderContextResultsWithSymbolsVerbose(query string, scored []knowledge.Sco
 func renderContextInternal(query string, scored []knowledge.ScoredNode, answer string, verbose bool) {
 	// Styles
 	var (
-		titleStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("205")).Bold(true)
-		sectionStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("141")).Bold(true)
+		titleStyle   = lipgloss.NewStyle().Foreground(ColorPrimary).Bold(true)
+		sectionStyle = lipgloss.NewStyle().Foreground(ColorPurple).Bold(true)
 	)
 
 	// Render Answer Panel
@@ -79,11 +79,11 @@ func renderContextInternal(query string, scored []knowledge.ScoredNode, answer s
 func renderScoredNodePanel(index int, s knowledge.ScoredNode, maxScore float32, verbose bool) {
 	// Styles
 	var (
-		headerStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Bold(true) // Cyan for headers
-		metaStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))           // Dim for metadata
-		contentStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("252"))           // Light for content
-		barFull      = lipgloss.NewStyle().Foreground(lipgloss.Color("42"))            // Green
-		barEmpty     = lipgloss.NewStyle().Foreground(lipgloss.Color("237"))           // Dark gray
+		headerStyle  = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "6", Dark: "14"}).Bold(true)
+		metaStyle    = lipgloss.NewStyle().Foreground(ColorSecondary)
+		contentStyle = lipgloss.NewStyle().Foreground(ColorText)
+		barFull      = lipgloss.NewStyle().Foreground(ColorSuccess)
+		barEmpty     = lipgloss.NewStyle().Foreground(ColorBarEmpty)
 		panelBorder  = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(scoreToColor(s.Score, maxScore)).Padding(0, 1).MarginTop(1)
 	)
 
@@ -167,15 +167,15 @@ func renderScoredNodePanel(index int, s knowledge.ScoredNode, maxScore float32, 
 }
 
 // scoreToColor returns a border color based on the score (green for high, yellow for medium, gray for low).
-func scoreToColor(score, maxScore float32) lipgloss.Color {
+func scoreToColor(score, maxScore float32) lipgloss.TerminalColor {
 	relative := score / maxScore
 	switch {
 	case relative >= 0.8:
-		return lipgloss.Color("42") // Green - high relevance
+		return ColorSuccess
 	case relative >= 0.5:
-		return lipgloss.Color("214") // Orange - medium relevance
+		return ColorWarning
 	default:
-		return lipgloss.Color("241") // Gray - lower relevance
+		return ColorSecondary
 	}
 }
 
@@ -183,8 +183,8 @@ func scoreToColor(score, maxScore float32) lipgloss.Color {
 func renderContextWithSymbolsInternal(query string, scored []knowledge.ScoredNode, symbols []app.SymbolResponse, answer string, verbose bool) {
 	// Styles
 	var (
-		titleStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("205")).Bold(true)
-		sectionStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("141")).Bold(true)
+		titleStyle   = lipgloss.NewStyle().Foreground(ColorPrimary).Bold(true)
+		sectionStyle = lipgloss.NewStyle().Foreground(ColorPurple).Bold(true)
 	)
 
 	// Render Answer Panel
@@ -233,10 +233,10 @@ func renderContextWithSymbolsInternal(query string, scored []knowledge.ScoredNod
 func renderSymbolPanel(index int, sym app.SymbolResponse, verbose bool) {
 	// Styles
 	var (
-		headerStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("14")).Bold(true)
-		metaStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
-		locationStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("39"))
-		panelBorder   = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("63")).Padding(0, 1).MarginTop(1)
+		headerStyle   = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "6", Dark: "14"}).Bold(true)
+		metaStyle     = lipgloss.NewStyle().Foreground(ColorSecondary)
+		locationStyle = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "25", Dark: "39"})
+		panelBorder   = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.AdaptiveColor{Light: "55", Dark: "63"}).Padding(0, 1).MarginTop(1)
 	)
 
 	icon := symbolKindIcon(sym.Kind)
@@ -308,7 +308,7 @@ func getContentWithoutSummary(content, summary string) string {
 // RenderAskResult displays a complete AskResult from the ask pipeline.
 // This is the primary rendering function for the `taskwing ask` command.
 func RenderAskResult(result *app.AskResult, verbose bool) {
-	sectionStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("141")).Bold(true)
+	sectionStyle := lipgloss.NewStyle().Foreground(ColorPurple).Bold(true)
 
 	// Header with query in a styled box
 	headerBox := lipgloss.NewStyle().

--- a/internal/ui/eval_report.go
+++ b/internal/ui/eval_report.go
@@ -72,7 +72,7 @@ var (
 			Foreground(ColorSuccess)
 
 	scoreBarEmpty = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("237"))
+			Foreground(ColorBarEmpty)
 
 	sectionStyle = lipgloss.NewStyle().
 			Foreground(ColorPrimary).

--- a/internal/ui/explain.go
+++ b/internal/ui/explain.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/josephgoksu/TaskWing/internal/app"
 )
 
@@ -161,8 +162,8 @@ func truncate(s string, max int) string {
 	return s[:max-3] + "..."
 }
 
-// StyleBold returns the text with bold ANSI codes.
-// This is a simple implementation - could use lipgloss for more styling.
+// StyleBold returns the text with bold styling via lipgloss.
+// Respects NO_COLOR automatically.
 func StyleBold(s string) string {
-	return "\033[1m" + s + "\033[0m"
+	return lipgloss.NewStyle().Bold(true).Render(s)
 }

--- a/internal/ui/prompt_key.go
+++ b/internal/ui/prompt_key.go
@@ -66,8 +66,8 @@ func (m apiKeyModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m apiKeyModel) View() string {
-	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12"))
-	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(ColorHighlight)
+	dimStyle := lipgloss.NewStyle().Foreground(ColorDim)
 
 	s := "\n" + titleStyle.Render("🔑 API Key required") + "\n"
 	s += dimStyle.Render("It will be stored locally in ~/.taskwing/config.yaml") + "\n\n"

--- a/internal/ui/spinner.go
+++ b/internal/ui/spinner.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -41,7 +42,7 @@ func (s *Spinner) Start() {
 		for {
 			select {
 			case <-s.stop:
-				fmt.Fprint(os.Stderr, "\r\033[K")
+				fmt.Fprint(os.Stderr, "\r"+strings.Repeat(" ", 80)+"\r")
 				return
 			case <-ticker.C:
 				frame := style.Render(frames[i%len(frames)])

--- a/internal/ui/spinner.go
+++ b/internal/ui/spinner.go
@@ -3,7 +3,6 @@ package ui
 import (
 	"fmt"
 	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -42,7 +41,7 @@ func (s *Spinner) Start() {
 		for {
 			select {
 			case <-s.stop:
-				fmt.Fprint(os.Stderr, "\r"+strings.Repeat(" ", 80)+"\r")
+				fmt.Fprint(os.Stderr, "\r\033[K")
 				return
 			case <-ticker.C:
 				frame := style.Render(frames[i%len(frames)])

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -7,19 +7,23 @@ import (
 )
 
 var (
-	// Colors
-	ColorPrimary   = lipgloss.Color("205") // Pink
-	ColorSecondary = lipgloss.Color("241") // Gray
-	ColorSuccess   = lipgloss.Color("42")  // Green
-	ColorError     = lipgloss.Color("160") // Red
-	ColorWarning   = lipgloss.Color("214") // Orange/Yellow
-	ColorText      = lipgloss.Color("252") // White/Gray
-	ColorCyan      = lipgloss.Color("87")  // Cyan for strategy
-	ColorBlue      = lipgloss.Color("75")  // Blue for answers
-	ColorHighlight = lipgloss.Color("12")  // Blue for titles/highlights
-	ColorSelected  = lipgloss.Color("10")  // Green for selected items
-	ColorDim       = lipgloss.Color("240") // Dim gray for secondary text
-	ColorYellow    = lipgloss.Color("11")  // Yellow for badges/accents
+	// Colors — AdaptiveColor auto-selects Light/Dark based on terminal background
+	ColorPrimary   = lipgloss.AdaptiveColor{Light: "161", Dark: "205"} // Pink
+	ColorSecondary = lipgloss.AdaptiveColor{Light: "244", Dark: "241"} // Gray
+	ColorSuccess   = lipgloss.AdaptiveColor{Light: "28", Dark: "42"}   // Green
+	ColorError     = lipgloss.AdaptiveColor{Light: "160", Dark: "160"} // Red
+	ColorWarning   = lipgloss.AdaptiveColor{Light: "172", Dark: "214"} // Orange/Yellow
+	ColorText      = lipgloss.AdaptiveColor{Light: "235", Dark: "252"} // Text
+	ColorCyan      = lipgloss.AdaptiveColor{Light: "30", Dark: "87"}   // Cyan for strategy
+	ColorBlue      = lipgloss.AdaptiveColor{Light: "27", Dark: "75"}   // Blue for answers
+	ColorHighlight = lipgloss.AdaptiveColor{Light: "4", Dark: "12"}    // Blue for titles/highlights
+	ColorSelected  = lipgloss.AdaptiveColor{Light: "2", Dark: "10"}    // Green for selected items
+	ColorDim       = lipgloss.AdaptiveColor{Light: "247", Dark: "240"} // Dim gray for secondary text
+	ColorYellow    = lipgloss.AdaptiveColor{Light: "136", Dark: "11"}  // Yellow for badges/accents
+
+	// Shared constants used across multiple views
+	ColorPurple   = lipgloss.AdaptiveColor{Light: "97", Dark: "141"}  // Purple for sections
+	ColorBarEmpty = lipgloss.AdaptiveColor{Light: "250", Dark: "237"} // Empty bar segments
 
 	// Base Styles
 	StyleTitle   = lipgloss.NewStyle().Foreground(ColorText).Bold(true)
@@ -84,8 +88,8 @@ var (
 	StyleSelectBadge  = lipgloss.NewStyle().Foreground(ColorYellow).Bold(true)
 
 	// Table Styles (alternating rows)
-	ColorTableRowEven = lipgloss.Color("236") // Subtle dark background
-	ColorTableRowOdd  = lipgloss.Color("234") // Slightly darker
+	ColorTableRowEven = lipgloss.AdaptiveColor{Light: "254", Dark: "236"} // Subtle background
+	ColorTableRowOdd  = lipgloss.AdaptiveColor{Light: "231", Dark: "234"} // Slightly different
 	StyleTableRowEven = lipgloss.NewStyle().Foreground(ColorText)
 	StyleTableRowOdd  = lipgloss.NewStyle().Foreground(ColorDim)
 	StyleTableHeader  = lipgloss.NewStyle().Bold(true).Foreground(ColorPrimary).Underline(true)
@@ -106,24 +110,24 @@ var (
 
 // CategoryBadge returns a styled badge string for a knowledge node type.
 func CategoryBadge(nodeType string) string {
-	colors := map[string]lipgloss.Color{
-		"decision":      lipgloss.Color("205"), // Pink
-		"feature":       lipgloss.Color("75"),  // Blue
-		"constraint":    lipgloss.Color("214"), // Orange
-		"pattern":       lipgloss.Color("141"), // Purple
-		"plan":          lipgloss.Color("42"),  // Green
-		"note":          lipgloss.Color("252"), // White
-		"metadata":      lipgloss.Color("87"),  // Cyan
-		"documentation": lipgloss.Color("11"),  // Yellow
+	colors := map[string]lipgloss.AdaptiveColor{
+		"decision":      ColorPrimary,
+		"feature":       ColorBlue,
+		"constraint":    ColorWarning,
+		"pattern":       ColorPurple,
+		"plan":          ColorSuccess,
+		"note":          ColorText,
+		"metadata":      ColorCyan,
+		"documentation": ColorYellow,
 	}
 
 	color, ok := colors[nodeType]
 	if !ok {
-		color = lipgloss.Color("241")
+		color = lipgloss.AdaptiveColor{Light: "244", Dark: "241"}
 	}
 
 	badge := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("0")).
+		Foreground(lipgloss.AdaptiveColor{Light: "231", Dark: "0"}).
 		Background(color).
 		Padding(0, 1).
 		Bold(true)

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -88,8 +88,6 @@ var (
 	StyleSelectBadge  = lipgloss.NewStyle().Foreground(ColorYellow).Bold(true)
 
 	// Table Styles (alternating rows)
-	ColorTableRowEven = lipgloss.AdaptiveColor{Light: "254", Dark: "236"} // Subtle background
-	ColorTableRowOdd  = lipgloss.AdaptiveColor{Light: "231", Dark: "234"} // Slightly different
 	StyleTableRowEven = lipgloss.NewStyle().Foreground(ColorText)
 	StyleTableRowOdd  = lipgloss.NewStyle().Foreground(ColorDim)
 	StyleTableHeader  = lipgloss.NewStyle().Bold(true).Foreground(ColorPrimary).Underline(true)
@@ -127,7 +125,7 @@ func CategoryBadge(nodeType string) string {
 	}
 
 	badge := lipgloss.NewStyle().
-		Foreground(lipgloss.AdaptiveColor{Light: "231", Dark: "0"}).
+		Foreground(lipgloss.AdaptiveColor{Light: "0", Dark: "0"}).
 		Background(color).
 		Padding(0, 1).
 		Bold(true)

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -1,9 +1,11 @@
 package ui
 
 import (
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"golang.org/x/term"
 )
 
 // Table renders data in a compact markdown-style table format.
@@ -37,6 +39,31 @@ func (t *Table) ColumnWidths() []int {
 		for i := range widths {
 			if widths[i] > t.MaxWidth {
 				widths[i] = t.MaxWidth
+			}
+		}
+	}
+
+	// Auto-constrain to terminal width when MaxWidth is not set
+	if t.MaxWidth == 0 {
+		termWidth := GetTerminalWidth()
+		// Account for leading space + column separators (2 chars between each column)
+		overhead := 1 + (len(widths)-1)*2
+		available := termWidth - overhead
+		if available > 0 {
+			total := 0
+			for _, w := range widths {
+				total += w
+			}
+			if total > available {
+				// Proportionally shrink columns, but keep a minimum of 4 chars
+				ratio := float64(available) / float64(total)
+				for i := range widths {
+					newW := int(float64(widths[i]) * ratio)
+					if newW < 4 {
+						newW = 4
+					}
+					widths[i] = newW
+				}
 			}
 		}
 	}
@@ -99,6 +126,15 @@ func padRight(s string, width int) string {
 		return s
 	}
 	return s + strings.Repeat(" ", width-len(s))
+}
+
+// GetTerminalWidth returns the current terminal width, defaulting to 80.
+func GetTerminalWidth() int {
+	w, _, err := term.GetSize(int(os.Stdout.Fd()))
+	if err != nil || w <= 0 {
+		return 80
+	}
+	return w
 }
 
 // TruncateID shortens an ID for display (first 6 chars).

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -47,7 +47,10 @@ func (t *Table) ColumnWidths() []int {
 	if t.MaxWidth == 0 {
 		termWidth := GetTerminalWidth()
 		// Account for leading space + column separators (2 chars between each column)
-		overhead := 1 + (len(widths)-1)*2
+		overhead := 1
+		if len(widths) > 1 {
+			overhead += (len(widths) - 1) * 2
+		}
 		available := termWidth - overhead
 		if available > 0 {
 			total := 0
@@ -63,6 +66,33 @@ func (t *Table) ColumnWidths() []int {
 						newW = 4
 					}
 					widths[i] = newW
+				}
+				// Post-clamp: if min-floor caused overflow, trim widest columns
+				for {
+					postTotal := 0
+					for _, w := range widths {
+						postTotal += w
+					}
+					excess := postTotal - available
+					if excess <= 0 {
+						break
+					}
+					// Find widest column and shrink it
+					maxIdx, maxW := 0, 0
+					for i, w := range widths {
+						if w > maxW {
+							maxIdx, maxW = i, w
+						}
+					}
+					// Don't shrink below minimum
+					if maxW <= 4 {
+						break
+					}
+					shrink := excess
+					if shrink > maxW-4 {
+						shrink = maxW - 4
+					}
+					widths[maxIdx] -= shrink
 				}
 			}
 		}
@@ -128,13 +158,18 @@ func padRight(s string, width int) string {
 	return s + strings.Repeat(" ", width-len(s))
 }
 
-// GetTerminalWidth returns the current terminal width, defaulting to 80.
-func GetTerminalWidth() int {
-	w, _, err := term.GetSize(int(os.Stdout.Fd()))
+// GetTerminalWidthFor returns the terminal width for the given file descriptor, defaulting to 80.
+func GetTerminalWidthFor(f *os.File) int {
+	w, _, err := term.GetSize(int(f.Fd()))
 	if err != nil || w <= 0 {
 		return 80
 	}
 	return w
+}
+
+// GetTerminalWidth returns the current stdout terminal width, defaulting to 80.
+func GetTerminalWidth() int {
+	return GetTerminalWidthFor(os.Stdout)
 }
 
 // TruncateID shortens an ID for display (first 6 chars).

--- a/internal/ui/utils.go
+++ b/internal/ui/utils.go
@@ -36,7 +36,7 @@ func RenderPageHeader(title, subtitle string) {
 type Panel struct {
 	Title       string
 	Content     string
-	BorderColor lipgloss.Color
+	BorderColor lipgloss.TerminalColor
 	Width       int
 }
 
@@ -51,7 +51,7 @@ func NewPanel(title, content string) *Panel {
 }
 
 // WithBorderColor sets the border color and returns the panel.
-func (p *Panel) WithBorderColor(color lipgloss.Color) *Panel {
+func (p *Panel) WithBorderColor(color lipgloss.TerminalColor) *Panel {
 	p.BorderColor = color
 	return p
 }


### PR DESCRIPTION
…inal width handling

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR upgrades the `internal/ui` package from hardcoded `lipgloss.Color` values to `lipgloss.AdaptiveColor` throughout, enabling proper light/dark terminal theme adaptation. It also introduces `GetTerminalWidth()` and auto-constraining column logic in `Table.ColumnWidths()`, migrates `StyleBold` to use lipgloss (gaining `NO_COLOR` support), widens the `Panel.BorderColor` API to accept any `lipgloss.TerminalColor`, and adds a "Why TaskWing?" performance comparison section to the README.

**Key issues found:**
- **`styles.go` (logic):** The `"note"` category in `CategoryBadge` maps to `ColorText` as its badge *background*. In light mode `ColorText.Light = "235"` resolves to near-black (#262626), producing an inverted dark badge inside a light theme — semantically wrong and visually inconsistent with all other badge types.
- **`table.go` (logic):** The new auto-constrain block in `ColumnWidths()` sums `widths[i]` values that are **byte lengths** (from `len(h)` / `len(cell)`) and compares them against the **terminal column count** from `GetTerminalWidth()`. For multi-byte Unicode content (emoji, CJK), the byte total overstates visual width, causing unnecessary and incorrect proportional shrinking. The `padRight` helper has the same `len(s)` issue; both should use `lipgloss.Width()` for visual measurement.
- **`README.md` (style):** The "Real session, real numbers" benchmark figures (token counts, timing) are single-datapoint, environment-specific measurements presented without caveats, which may mislead users whose repositories or models produce different results.
</details>

<h3>Confidence Score: 3/5</h3>

- Safe to merge for ASCII-only content, but has a light-mode visual regression for note badges and a measurement-unit bug that affects Unicode column sizing.
- The adaptive color migration is directionally correct and the majority of changes are improvements. However, two concrete logic bugs were found: (1) `ColorText` used as a badge background produces a visually inverted dark badge in light mode, a UX regression, and (2) the new auto-constrain path in `ColumnWidths()` mixes byte counts with terminal column counts, silently producing incorrect column widths for any Unicode content. These are functional regressions introduced by this PR, not pre-existing issues.
- `internal/ui/styles.go` (note badge background), `internal/ui/table.go` (byte-count vs column-count in auto-constrain), and `internal/ui/spinner.go` (hardcoded 80-char clear).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/ui/styles.go | Migrates all color constants from `lipgloss.Color` to `lipgloss.AdaptiveColor` for light/dark theme support; adds `ColorPurple` and `ColorBarEmpty` shared constants. `ColorText` is incorrectly reused as the "note" badge background, producing a near-black badge in light mode (a semantic inversion). `ColorTableRowEven`/`ColorTableRowOdd` remain declared but are still not applied in `StyleTableRowEven`/`StyleTableRowOdd`. |
| internal/ui/table.go | Adds `GetTerminalWidth()` and a new auto-constrain block in `ColumnWidths()`. The constrain logic mixes byte-count widths (`len(h)`, `len(cell)`) with terminal column count (`GetTerminalWidth()`), causing incorrect shrink ratios for Unicode content. The header/cell byte-count issue also affects `padRight`. |
| internal/ui/spinner.go | Replaces the ANSI EL escape (`\033[K`) with a hardcoded 80-space clear. This regresses wide-terminal support and the `strings` import is added specifically for `strings.Repeat`. |
| internal/ui/context_view.go | Replaces all hardcoded `lipgloss.Color` literals with adaptive color constants; changes `scoreToColor` return type from `lipgloss.Color` to `lipgloss.TerminalColor`. Inline `lipgloss.AdaptiveColor{Light: "6", Dark: "14"}` literal is duplicated across two render functions instead of being extracted to a named constant in styles.go. |
| internal/ui/config_menu.go | All four config menu styles migrated to `AdaptiveColor`. `configValueStyle` now uses `Light: "136"` (goldenrod, ~#af8700) as text foreground; on a white terminal background this yields approximately 3:1 contrast, borderline for readability. |
| README.md | Added a "Why TaskWing?" section with a comparison table and specific benchmark figures. Token counts and timing are presented as universally representative but are highly environment-specific; lacks reproducibility caveats. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Terminal Background Detection\nlipgloss.HasDarkBackground] --> B{Light or Dark?}
    B -->|Light| C[Resolve AdaptiveColor.Light]
    B -->|Dark| D[Resolve AdaptiveColor.Dark]

    C --> E[Named Color Constants\ne.g. ColorPrimary, ColorText, ColorWarning]
    D --> E

    E --> F[Package-Level Styles\nStyleTitle, StyleError, StyleSuccess ...]
    E --> G[In-Function Styles\nconfig_menu, context_view, spinner ...]
    E --> H[CategoryBadge\nnode type → AdaptiveColor background]

    F --> I[UI Components]
    G --> I
    H --> I

    I --> J[Table.Render]
    I --> K[Panel.Render]
    I --> L[Spinner.Start]
    I --> M[RenderContextResults]

    J --> N{MaxWidth set?}
    N -->|Yes| O[Apply MaxWidth cap per column]
    N -->|No| P[GetTerminalWidth via os.Stdout\nAuto-constrain column widths]
    P -->|byte-count total vs column-count available\n⚠️ Mixed units for Unicode| Q[Proportional shrink + min-4 clamp]
    O --> R[Render string output]
    Q --> R
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Ainternal%2Fui%2Fstyles.go%3A119%0A**%60ColorText%60%20misused%20as%20badge%20background%20for%20%22note%22%20type**%0A%0A%60ColorText%60%20is%20defined%20as%20%60%7BLight%3A%20%22235%22%2C%20Dark%3A%20%22252%22%7D%60.%20In%20light-mode%20terminals%2C%20%60%22235%22%60%20resolves%20to%20approximately%20%60%23262626%60%20%28near-black%29.%20Using%20a%20foreground-text%20color%20as%20a%20badge%20*background*%20causes%20a%20visual%20inversion%20in%20light%20mode%3A%20a%20%22note%22%20badge%20will%20render%20with%20a%20near-black%20background%2C%20which%20is%20jarring%20and%20semantically%20wrong%20when%20every%20other%20UI%20element%20in%20that%20theme%20is%20light.%0A%0AIn%20the%20old%20code%20this%20was%20%60lipgloss.Color%28%22252%22%29%60%20%E2%80%94%20a%20consistent%20light-gray%20in%20all%20modes.%20The%20new%20mapping%20produces%3A%0A-%20**Dark%20mode%3A**%20%60%22252%22%60%20%28%23d0d0d0%2C%20light%20gray%29%20background%20%E2%80%94%20visually%20light%20and%20subtle%2C%20fine.%0A-%20**Light%20mode%3A**%20%60%22235%22%60%20%28%23262626%2C%20near-black%29%20background%20%E2%80%94%20visually%20an%20inverted%2Fdark%20badge%20in%20a%20light%20theme%2C%20inconsistent%20with%20all%20other%20badge%20backgrounds.%0A%0AConsider%20introducing%20a%20dedicated%20neutral%20adaptive%20color%20for%20%22note%22%20badges%2C%20e.g.%3A%0A%0A%60%60%60go%0A%2F%2F%20in%20styles.go%0AColorNeutral%20%3D%20lipgloss.AdaptiveColor%7BLight%3A%20%22248%22%2C%20Dark%3A%20%22252%22%7D%20%2F%2F%20Neutral%20gray%20for%20note%20badges%0A%60%60%60%0A%0AThen%20in%20%60CategoryBadge%60%3A%0A%60%60%60suggestion%0A%09%09%22note%22%3A%20%20%20%20%20%20%20%20%20%20ColorNeutral%2C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Ainternal%2Fui%2Ftable.go%3A53-56%0A**Mixed%20byte-count%20vs.%20terminal-column%20comparison%20in%20auto-constrain%20logic**%0A%0A%60widths%5Bi%5D%60%20values%20are%20populated%20using%20%60len%28h%29%60%20%28header%29%20and%20%60len%28cell%29%60%20%28row%20cells%29%2C%20which%20return%20**byte%20lengths**.%20%60GetTerminalWidth%28%29%60%20returns%20**terminal%20columns**%20%28visual%20width%29.%20For%20pure%20ASCII%20these%20are%20equivalent%2C%20but%20multi-byte%20UTF-8%20content%20%28e.g.%2C%20emoji%20in%20headers%20like%20%60%22%F0%9F%94%8D%20Symbol%22%60%20used%20in%20%60explain.go%60%2C%20or%20CJK%20characters%29%20will%20cause%20%60total%60%20%28bytes%29%20to%20exceed%20%60available%60%20%28columns%29%20even%20when%20the%20table%20would%20visually%20fit%2C%20triggering%20unnecessary%20proportional%20shrinking.%20In%20extreme%20cases%20with%20wide%20characters%2C%20columns%20get%20over-shrunk%20and%20the%20table%20renders%20narrower%20than%20the%20terminal.%0A%0AThe%20fix%20is%20to%20measure%20visual%20width%20using%20%60lipgloss.Width%28s%29%60%20%28which%20accounts%20for%20Unicode%20and%20ANSI%20sequences%29%20when%20calculating%20%60widths%60%3A%0A%0A%60%60%60go%0A%2F%2F%20Instead%20of%20len%28h%29%20%2F%20len%28cell%29%2C%20use%3A%0Aimport%20%22github.com%2Fcharmbracelet%2Flipgloss%22%0A%0A%2F%2F%20In%20ColumnWidths%28%29%3A%0Afor%20i%2C%20h%20%3A%3D%20range%20t.Headers%20%7B%0A%20%20%20%20widths%5Bi%5D%20%3D%20lipgloss.Width%28h%29%0A%7D%0Afor%20_%2C%20row%20%3A%3D%20range%20t.Rows%20%7B%0A%20%20%20%20for%20i%2C%20cell%20%3A%3D%20range%20row%20%7B%0A%20%20%20%20%20%20%20%20if%20i%20%3C%20len%28widths%29%20%26%26%20lipgloss.Width%28cell%29%20%3E%20widths%5Bi%5D%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20widths%5Bi%5D%20%3D%20lipgloss.Width%28cell%29%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%7D%0A%60%60%60%0A%0A%60padRight%60%20has%20the%20same%20%60len%28s%29%60%20issue%20%E2%80%94%20it%20should%20also%20use%20%60lipgloss.Width%28s%29%60%20to%20avoid%20producing%20visually%20misaligned%20padding%20for%20Unicode%20content.%0A%0A%23%23%23%20Issue%203%20of%203%0AREADME.md%3A50-56%0A**Highly%20specific%20benchmark%20claims%20lack%20reproducibility%20caveats**%0A%0AThe%20figures%20%6025%2C000%20tokens%60%2C%20%601%2C500%20tokens%60%2C%20%6042%20seconds%60%2C%20and%20%603%20minutes%60%20are%20labeled%20%22Real%20session%2C%20real%20numbers%22%20but%20will%20vary%20significantly%20by%20repository%20size%2C%20AI%20model%2C%20query%20complexity%2C%20network%20latency%2C%20and%20TaskWing%20knowledge-base%20completeness.%20Presenting%20single-datapoint%20figures%20as%20representative%20benchmarks%20without%20any%20caveat%20could%20mislead%20users%20whose%20results%20differ%20substantially.%0A%0AConsider%20adding%20a%20qualifier%20such%20as%3A%0A%0A%60%60%60suggestion%0A**Real%20session%2C%20real%20numbers**%20*%28results%20vary%20by%20repository%20size%20and%20model%29*%20%E2%80%94%20asked%20*%22What%20are%20the%20bottlenecks%20in%20our%20engineering%20process%3F%22*%3A%0A%60%60%60%0A%0AOr%20add%20a%20footnote%20explaining%20the%20test%20environment%20%28repo%20LOC%2C%20model%20used%2C%20knowledge-base%20node%20count%29.%0A%0A&repo=josephgoksu%2Ftaskwing"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<sub>Last reviewed commit: 3a83f9b</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->