### PR TITLE
feat(migration): auto-migrate configs after CLI upgrade

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -195,6 +195,7 @@ func runBootstrap(cmd *cobra.Command, args []string) error {
 
 	// Initialize Service
 	svc := bootstrap.NewService(cwd, llmCfg)
+	svc.SetVersion(version)
 
 	// Prompt for repo selection in multi-repo workspaces.
 	// This must happen before the action loop because ActionInitProject may not

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/josephgoksu/TaskWing/internal/config"
 	"github.com/josephgoksu/TaskWing/internal/logger"
+	"github.com/josephgoksu/TaskWing/internal/migration"
 	"github.com/josephgoksu/TaskWing/internal/telemetry"
 	"github.com/josephgoksu/TaskWing/internal/ui"
 	"github.com/spf13/cobra"
@@ -55,7 +56,13 @@ var rootCmd = &cobra.Command{
 
 Create a plan, execute tasks with your AI tool, and keep architecture context
 persistent across sessions.`,
-	PersistentPreRunE:  initTelemetry,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if err := initTelemetry(cmd, args); err != nil {
+			return err
+		}
+		maybeRunPostUpgradeMigration(cmd)
+		return nil
+	},
 	PersistentPostRunE: closeTelemetry,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
@@ -171,6 +178,31 @@ func init() {
 // GetVersion returns the application version
 func GetVersion() string {
 	return version
+}
+
+// maybeRunPostUpgradeMigration runs a one-time migration when the CLI version
+// changes (e.g., after brew upgrade). Skips commands that don't need project context.
+func maybeRunPostUpgradeMigration(cmd *cobra.Command) {
+	// Skip commands that don't need project context
+	name := cmd.Name()
+	if name == "version" || name == "help" || name == "mcp" {
+		return
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+
+	warnings, err := migration.CheckAndMigrate(cwd, version)
+	if err != nil {
+		// Migration errors are non-fatal
+		return
+	}
+
+	for _, w := range warnings {
+		fmt.Fprintf(os.Stderr, "⚠️  %s\n", w)
+	}
 }
 
 // initTelemetry initializes the telemetry client.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -183,10 +183,12 @@ func GetVersion() string {
 // maybeRunPostUpgradeMigration runs a one-time migration when the CLI version
 // changes (e.g., after brew upgrade). Skips commands that don't need project context.
 func maybeRunPostUpgradeMigration(cmd *cobra.Command) {
-	// Skip commands that don't need project context
-	name := cmd.Name()
-	if name == "version" || name == "help" || name == "mcp" {
-		return
+	// Skip the entire mcp subtree (and other commands that don't need migration)
+	for c := cmd; c != nil; c = c.Parent() {
+		n := c.Name()
+		if n == "version" || n == "help" || n == "mcp" {
+			return
+		}
 	}
 
 	cwd, err := os.Getwd()

--- a/internal/bootstrap/initializer.go
+++ b/internal/bootstrap/initializer.go
@@ -16,6 +16,9 @@ import (
 // Initializer handles the setup of TaskWing project structure and integrations.
 type Initializer struct {
 	basePath string
+	// Version is the CLI version to stamp in .taskwing/version.
+	// If empty, no version file is written.
+	Version string
 }
 
 func NewInitializer(basePath string) *Initializer {
@@ -216,6 +219,13 @@ func (i *Initializer) createStructure(verbose bool) error {
 			fmt.Printf("  ✓ Created %s\n", dir)
 		}
 	}
+
+	// Track CLI version for post-upgrade migration detection
+	if i.Version != "" {
+		versionPath := filepath.Join(i.basePath, ".taskwing", "version")
+		_ = os.WriteFile(versionPath, []byte(i.Version), 0644)
+	}
+
 	return nil
 }
 
@@ -247,6 +257,26 @@ var aiHelpers = func() map[string]aiHelperConfig {
 	}
 	return cfg
 }()
+
+// AIHelperInfo exposes read-only AI config fields needed by external packages.
+type AIHelperInfo struct {
+	CommandsDir    string
+	SingleFile     bool
+	SingleFileName string
+}
+
+// AIHelperByName returns exported config info for the named AI, if it exists.
+func AIHelperByName(name string) (AIHelperInfo, bool) {
+	cfg, ok := aiHelpers[name]
+	if !ok {
+		return AIHelperInfo{}, false
+	}
+	return AIHelperInfo{
+		CommandsDir:    cfg.commandsDir,
+		SingleFile:     cfg.singleFile,
+		SingleFileName: cfg.singleFileName,
+	}, true
+}
 
 // TaskWingManagedFile is the marker file name written to directories managed by TaskWing.
 // This file indicates that TaskWing created and owns the directory, preventing false positives

--- a/internal/bootstrap/service.go
+++ b/internal/bootstrap/service.go
@@ -40,6 +40,12 @@ func NewService(basePath string, llmCfg llm.Config) *Service {
 	}
 }
 
+// SetVersion sets the CLI version on the underlying initializer so that
+// createStructure() stamps .taskwing/version for post-upgrade migration detection.
+func (s *Service) SetVersion(v string) {
+	s.initializer.Version = v
+}
+
 // InitializeProject sets up the .taskwing directory structure and integrations.
 func (s *Service) InitializeProject(verbose bool, selectedAIs []string) error {
 	return s.initializer.Run(verbose, selectedAIs)

--- a/internal/migration/upgrade.go
+++ b/internal/migration/upgrade.go
@@ -1,0 +1,127 @@
+package migration
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/josephgoksu/TaskWing/internal/bootstrap"
+	"github.com/josephgoksu/TaskWing/internal/mcpcfg"
+)
+
+// CheckAndMigrate runs a post-upgrade migration if the CLI version has changed
+// since the last run in this project. It silently regenerates local configs and
+// returns warnings for issues that require manual intervention (e.g., global MCP).
+//
+// This is designed to be called from PersistentPreRunE and must be:
+//   - Sub-millisecond on the happy path (version matches)
+//   - Non-fatal on all error paths (never blocks user commands)
+func CheckAndMigrate(projectDir, currentVersion string) (warnings []string, err error) {
+	taskwingDir := filepath.Join(projectDir, ".taskwing")
+	versionFile := filepath.Join(taskwingDir, "version")
+
+	// Not bootstrapped or inaccessible — nothing to migrate
+	if _, err := os.Stat(taskwingDir); err != nil {
+		return nil, nil
+	}
+
+	stored, err := os.ReadFile(versionFile)
+	if err != nil {
+		// Version file missing (pre-migration bootstrap). Write current and return.
+		_ = os.WriteFile(versionFile, []byte(currentVersion), 0644)
+		return nil, nil
+	}
+
+	storedVersion := strings.TrimSpace(string(stored))
+
+	// Happy path: version matches — no-op
+	if storedVersion == currentVersion {
+		return nil, nil
+	}
+
+	// Skip dev builds to avoid constant re-runs during development
+	if currentVersion == "dev" {
+		return nil, nil
+	}
+
+	// --- Version mismatch: run migration ---
+
+	// 1. Silent local migration: regenerate slash commands for managed AIs
+	migrateLocalConfigs(projectDir)
+
+	// 2. Global MCP check: warn about legacy server names
+	warnings = checkGlobalMCPLegacy()
+
+	// 3. Write current version
+	_ = os.WriteFile(versionFile, []byte(currentVersion), 0644)
+
+	return warnings, nil
+}
+
+// migrateLocalConfigs detects which AIs have managed markers and regenerates
+// their slash commands (which internally prunes stale tw-* files).
+func migrateLocalConfigs(projectDir string) {
+	for _, aiName := range bootstrap.ValidAINames() {
+		cfg, ok := bootstrap.AIHelperByName(aiName)
+		if !ok {
+			continue
+		}
+
+		// Check if this AI has a managed marker
+		if cfg.SingleFile {
+			// Single-file AIs (e.g., Copilot) embed the marker in file content.
+			// Check for the embedded marker before regenerating.
+			filePath := filepath.Join(projectDir, cfg.CommandsDir, cfg.SingleFileName)
+			content, err := os.ReadFile(filePath)
+			if err != nil || !strings.Contains(string(content), "<!-- TASKWING_MANAGED -->") {
+				continue
+			}
+		} else {
+			markerPath := filepath.Join(projectDir, cfg.CommandsDir, bootstrap.TaskWingManagedFile)
+			if _, err := os.Stat(markerPath); err != nil {
+				continue
+			}
+		}
+
+		// Regenerate (this prunes stale files and creates new ones)
+		init := bootstrap.NewInitializer(projectDir)
+		_ = init.CreateSlashCommands(aiName, false)
+	}
+}
+
+// checkGlobalMCPLegacy reads Claude's global MCP config and warns if legacy
+// server names are present.
+func checkGlobalMCPLegacy() []string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	configPath := filepath.Join(home, ".claude", "claude_desktop_config.json")
+	return checkGlobalMCPLegacyAt(configPath)
+}
+
+// checkGlobalMCPLegacyAt checks a specific config file path for legacy server names.
+func checkGlobalMCPLegacyAt(configPath string) []string {
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil
+	}
+
+	var config struct {
+		MCPServers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(content, &config); err != nil {
+		return nil
+	}
+
+	var warnings []string
+	for name := range config.MCPServers {
+		if mcpcfg.IsLegacyServerName(name) {
+			warnings = append(warnings, fmt.Sprintf("Global MCP config has legacy server name %q. Run: taskwing doctor --fix --yes", name))
+		}
+	}
+
+	return warnings
+}

--- a/internal/migration/upgrade.go
+++ b/internal/migration/upgrade.go
@@ -30,7 +30,9 @@ func CheckAndMigrate(projectDir, currentVersion string) (warnings []string, err 
 	stored, err := os.ReadFile(versionFile)
 	if err != nil {
 		// Version file missing (pre-migration bootstrap). Write current and return.
-		_ = os.WriteFile(versionFile, []byte(currentVersion), 0644)
+		if werr := os.WriteFile(versionFile, []byte(currentVersion), 0644); werr != nil {
+			fmt.Fprintf(os.Stderr, "⚠️  taskwing: could not write version stamp (%v); migration will re-run next time\n", werr)
+		}
 		return nil, nil
 	}
 
@@ -55,7 +57,9 @@ func CheckAndMigrate(projectDir, currentVersion string) (warnings []string, err 
 	warnings = checkGlobalMCPLegacy()
 
 	// 3. Write current version
-	_ = os.WriteFile(versionFile, []byte(currentVersion), 0644)
+	if werr := os.WriteFile(versionFile, []byte(currentVersion), 0644); werr != nil {
+		fmt.Fprintf(os.Stderr, "⚠️  taskwing: could not write version stamp (%v); migration will re-run next time\n", werr)
+	}
 
 	return warnings, nil
 }
@@ -86,8 +90,10 @@ func migrateLocalConfigs(projectDir string) {
 		}
 
 		// Regenerate (this prunes stale files and creates new ones)
-		init := bootstrap.NewInitializer(projectDir)
-		_ = init.CreateSlashCommands(aiName, false)
+		initializer := bootstrap.NewInitializer(projectDir)
+		if err := initializer.CreateSlashCommands(aiName, false); err != nil {
+			fmt.Fprintf(os.Stderr, "⚠️  taskwing: could not regenerate %s commands: %v\n", aiName, err)
+		}
 	}
 }
 

--- a/internal/migration/upgrade_test.go
+++ b/internal/migration/upgrade_test.go
@@ -1,0 +1,204 @@
+package migration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/josephgoksu/TaskWing/internal/bootstrap"
+)
+
+func TestNoMigrationWhenNotBootstrapped(t *testing.T) {
+	dir := t.TempDir()
+	warnings, err := CheckAndMigrate(dir, "1.22.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %v", warnings)
+	}
+	// Version file should not be created
+	if _, err := os.Stat(filepath.Join(dir, ".taskwing", "version")); !os.IsNotExist(err) {
+		t.Fatal("version file should not exist when not bootstrapped")
+	}
+}
+
+func TestNoMigrationWhenVersionMatches(t *testing.T) {
+	dir := t.TempDir()
+	twDir := filepath.Join(dir, ".taskwing")
+	if err := os.MkdirAll(twDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(twDir, "version"), []byte("1.22.0"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	warnings, err := CheckAndMigrate(dir, "1.22.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %v", warnings)
+	}
+}
+
+func TestNoMigrationForDevVersion(t *testing.T) {
+	dir := t.TempDir()
+	twDir := filepath.Join(dir, ".taskwing")
+	if err := os.MkdirAll(twDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(twDir, "version"), []byte("1.21.4"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	warnings, err := CheckAndMigrate(dir, "dev")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %v", warnings)
+	}
+
+	// Version file should NOT be updated to "dev"
+	stored, _ := os.ReadFile(filepath.Join(twDir, "version"))
+	if string(stored) != "1.21.4" {
+		t.Fatalf("version should remain 1.21.4, got %q", string(stored))
+	}
+}
+
+func TestMigrationRunsOnVersionChange(t *testing.T) {
+	dir := t.TempDir()
+	twDir := filepath.Join(dir, ".taskwing")
+	if err := os.MkdirAll(twDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(twDir, "version"), []byte("1.21.4"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a managed Claude commands directory with a legacy tw-ask.md file
+	claudeDir := filepath.Join(dir, ".claude", "commands")
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	markerContent := "# This directory is managed by TaskWing\n# AI: claude\n# Version: old\n"
+	if err := os.WriteFile(filepath.Join(claudeDir, bootstrap.TaskWingManagedFile), []byte(markerContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Write a legacy tw-ask.md file that should get pruned
+	if err := os.WriteFile(filepath.Join(claudeDir, "tw-ask.md"), []byte("legacy"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	warnings, err := CheckAndMigrate(dir, "1.22.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// No global MCP warnings expected in test (no real home dir config)
+	_ = warnings
+
+	// Version file should be updated
+	stored, _ := os.ReadFile(filepath.Join(twDir, "version"))
+	if string(stored) != "1.22.0" {
+		t.Fatalf("version should be 1.22.0, got %q", string(stored))
+	}
+
+	// Legacy tw-ask.md should be removed
+	if _, err := os.Stat(filepath.Join(claudeDir, "tw-ask.md")); !os.IsNotExist(err) {
+		t.Fatal("legacy tw-ask.md should have been pruned")
+	}
+
+	// New namespace directory should exist with regenerated commands
+	nsDir := filepath.Join(claudeDir, "taskwing")
+	if _, err := os.Stat(nsDir); os.IsNotExist(err) {
+		t.Fatal("taskwing/ namespace directory should have been created")
+	}
+}
+
+func TestMigrationIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	twDir := filepath.Join(dir, ".taskwing")
+	if err := os.MkdirAll(twDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(twDir, "version"), []byte("1.21.4"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create managed Claude config
+	claudeDir := filepath.Join(dir, ".claude", "commands")
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	markerContent := "# This directory is managed by TaskWing\n# AI: claude\n# Version: old\n"
+	if err := os.WriteFile(filepath.Join(claudeDir, bootstrap.TaskWingManagedFile), []byte(markerContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run migration twice
+	_, err := CheckAndMigrate(dir, "1.22.0")
+	if err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+
+	// Second run should be a no-op (version now matches)
+	warnings, err := CheckAndMigrate(dir, "1.22.0")
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("second run should produce no warnings, got %v", warnings)
+	}
+}
+
+func TestMigrationWritesVersionOnFirstEncounter(t *testing.T) {
+	dir := t.TempDir()
+	twDir := filepath.Join(dir, ".taskwing")
+	if err := os.MkdirAll(twDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// No version file exists (pre-migration bootstrap)
+
+	warnings, err := CheckAndMigrate(dir, "1.22.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %v", warnings)
+	}
+
+	// Version file should be stamped
+	stored, err := os.ReadFile(filepath.Join(twDir, "version"))
+	if err != nil {
+		t.Fatal("version file should exist after first encounter")
+	}
+	if string(stored) != "1.22.0" {
+		t.Fatalf("version should be 1.22.0, got %q", string(stored))
+	}
+}
+
+func TestGlobalMCPWarning(t *testing.T) {
+	// checkGlobalMCPLegacy reads from the real home dir, which we can't
+	// easily mock. Instead, test the function directly with a temp config.
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	config := `{"mcpServers":{"taskwing-mcp":{"command":"taskwing","args":["mcp"]}}}`
+	configPath := filepath.Join(configDir, "claude_desktop_config.json")
+	if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Call the internal function with overridden home
+	warnings := checkGlobalMCPLegacyAt(configPath)
+	if len(warnings) == 0 {
+		t.Fatal("expected warning about legacy server name")
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d", len(warnings))
+	}
+}


### PR DESCRIPTION
## Summary

- After `brew upgrade`, users have stale configs (old `tw-*` slash command files, legacy `taskwing-mcp` MCP entries). This adds a lightweight version check to `PersistentPreRunE` that auto-repairs local configs silently on the next command after upgrade.
- Stamps `.taskwing/version` during bootstrap; on version mismatch, regenerates slash commands for all managed AIs (pruning stale `tw-*` files) and warns about legacy global MCP server names.
- Happy path is sub-millisecond (1 stat + 1 file read + string compare). Migration path ~100ms, runs once per version per project. Skipped for `version`, `help`, `mcp` commands and `dev` builds.

## Files changed

| File | Change |
|------|--------|
| `internal/migration/upgrade.go` | **New** — `CheckAndMigrate()` core logic |
| `internal/migration/upgrade_test.go` | **New** — 7 tests (skip cases, migration, idempotency, warnings) |
| `cmd/root.go` | Hook `maybeRunPostUpgradeMigration` into `PersistentPreRunE` |
| `cmd/bootstrap.go` | Pass CLI version to service for stamping |
| `internal/bootstrap/initializer.go` | `Version` field, `AIHelperByName()` accessor, version stamp in `createStructure()` |
| `internal/bootstrap/service.go` | `SetVersion()` method |

## Test plan

- [x] `go test ./... -count=1 -short` — 193 tests pass across 32 packages
- [x] `go build ./...` — clean build
- [ ] Manual: `echo "1.21.4" > .taskwing/version && ./bin/taskwing doctor` → verify old `tw-*` files removed, new `taskwing/` commands created, version updated
- [ ] Manual: verify no output on repeated run (idempotent)
- [ ] Manual: verify `taskwing mcp` (stdio server) is not affected

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a lightweight post-upgrade migration system that detects CLI version changes after `brew upgrade` and automatically regenerates stale AI slash command files and warns about legacy MCP server names. The design intent is solid — version-stamp at bootstrap, compare on every command invocation, migrate once and re-stamp. The happy path is correctly sub-millisecond and the migration is non-fatal throughout.

**Key issues found:**

1. **Broken `mcp` subcommand skip** (`cmd/root.go`): `cmd.Name()` returns the leaf command name, so any subcommand under `mcp` (e.g., `mcp install`) has `cmd.Name()` != `"mcp"`, bypassing the guard. The migration will run for subcommands when it shouldn't. Fix requires walking up the parent chain to detect the entire `mcp` subtree.

2. **Silent infinite re-migration loop** (`internal/migration/upgrade.go`): Both version stamp writes silently discard errors with `_ = `. On a read-only or full filesystem, the version is never updated, causing the migration to re-run on every command indefinitely with no user feedback — a hidden performance regression.

3. **`init` shadows Go built-in** (`internal/migration/upgrade.go`): The local variable `init := bootstrap.NewInitializer(...)` shadows Go's reserved `init` identifier. `golangci-lint` will flag this; rename to `initializer`.

4. **`CreateSlashCommands` errors silently discarded** (`internal/migration/upgrade.go`): Failed slash command regeneration (e.g., permissions) is swallowed — the broken state is marked as successfully migrated and never retried, with zero diagnostic feedback.

The implementation approach is sound, but these four correctness gaps should be addressed: the `mcp` skip guard doesn't protect subcommands, silent write failures create a performance regression, lint violations, and missing error visibility.
</details>

<h3>Confidence Score: 3/5</h3>

- Mergeable with known correctness issues — migration is non-fatal so no user-blocking bugs, but the mcp skip guard, silent write failures, and error handling gaps should be fixed before production use at scale.
- Four verified logic and style issues present. The `mcp` skip guard doesn't protect subcommands (allowing migration to run unexpectedly), both version write operations silently ignore errors (creating permanent re-migration loops on filesystem failures), the `init` variable shadows Go's built-in (lint failure), and `CreateSlashCommands` errors are discarded (hiding broken states). The silent write-failure issue is particularly concerning because it turns the happy-path ~1ms check into a permanent per-command loop on any filesystem error. However, the migration is non-fatal and correctness gaps are fixable without redesign.
- `internal/migration/upgrade.go` (3 issues: init shadowing, write error handling, CreateSlashCommands errors) and `cmd/root.go` (mcp skip guard incomplete) require the most attention.

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant RootCmd as cmd/root.go (PersistentPreRunE)
    participant Migration as migration.CheckAndMigrate
    participant FS as Filesystem (.taskwing/version)
    participant Bootstrap as bootstrap.Initializer
    participant MCPCfg as mcpcfg.IsLegacyServerName

    User->>RootCmd: taskwing <any-command>
    RootCmd->>RootCmd: initTelemetry()
    RootCmd->>RootCmd: maybeRunPostUpgradeMigration(cmd)
    Note over RootCmd: Skip if cmd.Name() == "version"|"help"|"mcp"<br/>(⚠️ does NOT match mcp subcommands)
    RootCmd->>Migration: CheckAndMigrate(cwd, version)
    Migration->>FS: os.Stat(.taskwing/)
    alt Not bootstrapped
        Migration-->>RootCmd: nil, nil (no-op)
    else Bootstrapped
        Migration->>FS: os.ReadFile(.taskwing/version)
        alt Version file missing
            Migration->>FS: os.WriteFile(version) ⚠️ error silently dropped
            Migration-->>RootCmd: nil, nil
        else Version matches
            Migration-->>RootCmd: nil, nil (happy path, ~sub-ms)
        else currentVersion == "dev"
            Migration-->>RootCmd: nil, nil (skip dev builds)
        else Version mismatch
            Migration->>Bootstrap: migrateLocalConfigs(projectDir)
            loop For each managed AI
                Bootstrap->>FS: Check marker file
                Bootstrap->>Bootstrap: NewInitializer(projectDir)<br/>⚠️ named "init" (shadows built-in)
                Bootstrap->>Bootstrap: CreateSlashCommands(aiName)<br/>⚠️ error silently dropped
            end
            Migration->>MCPCfg: checkGlobalMCPLegacy()
            MCPCfg-->>Migration: []warnings
            Migration->>FS: os.WriteFile(version) ⚠️ error silently dropped
            Migration-->>RootCmd: warnings, nil
        end
    end
    RootCmd->>User: fmt.Fprintf(stderr, warnings...)
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Ainternal%2Fmigration%2Fupgrade.go%3A89-90%0A%60init%60%20is%20a%20reserved%20identifier%20in%20Go%20used%20for%20package%20initialization%20functions.%20Naming%20a%20local%20variable%20%60init%60%20will%20trigger%20%60golangci-lint%60%20%28%60predeclared%60%20checker%29%20and%20is%20confusing%20for%20readers.%20Rename%20to%20%60initializer%60%20or%20%60initer%60.%0A%0A%60%60%60suggestion%0A%09%09initializer%20%3A%3D%20bootstrap.NewInitializer%28projectDir%29%0A%09%09_%20%3D%20initializer.CreateSlashCommands%28aiName%2C%20false%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Acmd%2Froot.go%3A185-190%0A%60cmd.Name%28%29%60%20in%20%60PersistentPreRunE%60%20returns%20the%20**leaf**%20command%20being%20executed%2C%20not%20the%20root.%20When%20a%20user%20runs%20%60taskwing%20mcp%20install%20cursor%60%20%28or%20any%20subcommand%20under%20%60mcp%60%29%2C%20%60cmd.Name%28%29%60%20will%20return%20%60%22install%22%60%2C%20not%20%60%22mcp%22%60.%20The%20check%20%60name%20%3D%3D%20%22mcp%22%60%20only%20matches%20the%20bare%20%60taskwing%20mcp%60%20invocation%20itself.%0A%0AThe%20PR%20description%20states%20the%20intent%20to%20skip%20the%20%60mcp%60%20command%20%E2%80%94%20but%20subcommands%20under%20%60mcp%60%20would%20slip%20through%20this%20guard.%20The%20migration%20will%20run%20inside%20these%20subcommands%2C%20which%20violates%20the%20stated%20protection.%0A%0AFix%20by%20walking%20up%20the%20parent%20chain%20to%20detect%20the%20entire%20%60mcp%60%20subtree%3A%0A%60%60%60suggestion%0A%09%2F%2F%20Skip%20the%20entire%20mcp%20subtree%20%28and%20other%20commands%20that%20don't%20need%20migration%29%0A%09for%20c%20%3A%3D%20cmd%3B%20c%20!%3D%20nil%3B%20c%20%3D%20c.Parent%28%29%20%7B%0A%09%09n%20%3A%3D%20c.Name%28%29%0A%09%09if%20n%20%3D%3D%20%22version%22%20%7C%7C%20n%20%3D%3D%20%22help%22%20%7C%7C%20n%20%3D%3D%20%22mcp%22%20%7B%0A%09%09%09return%0A%09%09%7D%0A%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Ainternal%2Fmigration%2Fupgrade.go%3A30-35%0ABoth%20%60os.WriteFile%60%20calls%20%28lines%2033%20and%2058%29%20silently%20discard%20their%20errors%20with%20%60_%20%3D%20%60.%20If%20either%20write%20fails%20%28read-only%20filesystem%2C%20permissions%20error%2C%20disk%20full%29%2C%20the%20version%20file%20is%20never%20stamped.%20On%20the%20very%20next%20command%20invocation%2C%20the%20same%20sequence%20repeats%20%E2%80%94%20%60os.ReadFile%60%20fails%2C%20%60os.WriteFile%60%20is%20attempted%20again%20and%20fails%20silently.%20The%20user%20enters%20a%20permanent%20fail%E2%86%92retry%E2%86%92fail%20cycle%20on%20every%20command%20with%20zero%20feedback.%0A%0AAt%20minimum%2C%20log%20a%20non-fatal%20warning%20to%20%60stderr%60%20so%20the%20operator%20knows%20there's%20a%20filesystem%20issue.%20Failing%20silently%20is%20acceptable%20for%20non-fatal%20paths%2C%20but%20not%20when%20it%20creates%20a%20performance%20regression%20on%20every%20invocation%3A%0A%0A%60%60%60suggestion%0Aif%20err%20%3A%3D%20os.WriteFile%28versionFile%2C%20%5B%5Dbyte%28currentVersion%29%2C%200644%29%3B%20err%20!%3D%20nil%20%7B%0A%20%20%20%20fmt.Fprintf%28os.Stderr%2C%20%22%E2%9A%A0%EF%B8%8F%20%20taskwing%3A%20could%20not%20write%20version%20stamp%20%28%25v%29%3B%20migration%20will%20re-run%20next%20time%5Cn%22%2C%20err%29%0A%7D%0A%60%60%60%0A%0AApply%20the%20same%20pattern%20at%20line%2058%20after%20a%20successful%20migration.%0A%0A%23%23%23%20Issue%204%20of%204%0Ainternal%2Fmigration%2Fupgrade.go%3A88-91%0A%60_%20%3D%20init.CreateSlashCommands%28aiName%2C%20false%29%60%20discards%20the%20error%20entirely.%20If%20slash%20command%20regeneration%20fails%20for%20an%20AI%20%28e.g.%2C%20permission%20denied%20on%20%60.claude%2Fcommands%2F%60%29%2C%20the%20user%20sees%20no%20indication%2C%20the%20stale%20%60tw-*%60%20files%20survive%2C%20and%20the%20version%20is%20still%20stamped%20as%20migrated%20%E2%80%94%20meaning%20this%20broken%20state%20is%20never%20retried.%0A%0AConsider%20at%20least%20logging%20a%20non-fatal%20warning%20to%20give%20the%20operator%20visibility%3A%0A%0A%60%60%60suggestion%0Aif%20err%20%3A%3D%20initializer.CreateSlashCommands%28aiName%2C%20false%29%3B%20err%20!%3D%20nil%20%7B%0A%20%20%20%20fmt.Fprintf%28os.Stderr%2C%20%22%E2%9A%A0%EF%B8%8F%20%20taskwing%3A%20could%20not%20regenerate%20%25s%20commands%3A%20%25v%5Cn%22%2C%20aiName%2C%20err%29%0A%7D%0A%60%60%60%0A%0A&repo=josephgoksu%2Ftaskwing"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<sub>Last reviewed commit: d6a52c6</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->