### PR TITLE
feat: local-first repositioning + query-time freshness validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@
 
 ## TaskWing Integration
 
-TaskWing helps turn a goal into executed tasks with persistent context across AI sessions.
+TaskWing extracts architectural knowledge from your codebase and stores it locally, giving every AI tool instant context via MCP.
 
 ### Supported Models
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ air                           # Start hot-reload dev server (creates ./bin/taskw
 
 ## Architecture Overview
 
-TaskWing gives AI coding assistants permanent memory. It extracts architectural decisions, patterns, and constraints from your codebase, then exposes them via MCP (Model Context Protocol) so Claude, Cursor, and Copilot understand your architecture.
+TaskWing is a local-first AI knowledge layer. It extracts architectural decisions, patterns, and constraints from your codebase into local SQLite, then exposes them via MCP (Model Context Protocol) so Claude, Cursor, and Copilot understand your architecture.
 
 ### Core Layers
 
@@ -310,7 +310,7 @@ Interactive script that prompts for version, opens editor for notes, creates tag
 
 ## TaskWing Integration
 
-TaskWing helps turn a goal into executed tasks with persistent context across AI sessions.
+TaskWing extracts architectural knowledge from your codebase and stores it locally, giving every AI tool instant context via MCP.
 
 ### Supported Models
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-**TaskWing** is an AI-native task management CLI that gives AI tools "project memory." It extracts architectural decisions, patterns, and constraints from your codebase and makes them queryable by AI assistants (like Gemini, Claude, Cursor) via the Model Context Protocol (MCP).
+**TaskWing** is a local-first AI knowledge layer for development. It extracts architectural decisions, patterns, and constraints from your codebase into local SQLite and makes them queryable by AI assistants (like Gemini, Claude, Cursor) via the Model Context Protocol (MCP).
 
 **Core Value Proposition:**
 
@@ -189,7 +189,7 @@ Interactive script that prompts for version, opens editor for notes, creates tag
 
 ## TaskWing Integration
 
-TaskWing helps turn a goal into executed tasks with persistent context across AI sessions.
+TaskWing extracts architectural knowledge from your codebase and stores it locally, giving every AI tool instant context via MCP.
 
 ### Supported Models
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <br>
 </h1>
 
-<h3 align="center">Give your AI tools <em>a brain.</em></h3>
+<h3 align="center">The local-first knowledge layer for AI development.</h3>
 
 <p align="center">
   <a href="https://taskwing.app">Website</a> ·
@@ -26,16 +26,16 @@
 
 ---
 
-Your AI tools start every session from zero. They don't know your stack, your patterns, or why you chose PostgreSQL over MongoDB.
+Your AI tools start every session from zero -- and every session, your code context flows through someone else's cloud.
 
-**TaskWing fixes this.** One command extracts your architecture into a local database. Every AI session after that just *knows*.
+**TaskWing takes the opposite approach.** One command extracts your architecture into a local knowledge base on your machine. No cloud. No account. Every AI session after that just *knows* -- without your knowledge base leaving your infrastructure.
 
 ```
 Without TaskWing              With TaskWing
 ─────────────────             ─────────────
-8–12 file reads               1 MCP query
+8-12 file reads               1 MCP query
 ~25,000 tokens                ~1,500 tokens
-2–3 minutes                   42 seconds
+2-3 minutes                   42 seconds
 Zero persistent context       170+ knowledge nodes
 ```
 
@@ -61,14 +61,14 @@ curl -fsSL https://taskwing.app/install.sh | sh
 # 1. Extract your architecture (one-time)
 cd your-project
 taskwing bootstrap
-# → 22 decisions, 12 patterns, 9 constraints extracted
+# -> 22 decisions, 12 patterns, 9 constraints extracted
 
 # 2. Connect to your AI tool
 taskwing mcp install claude    # or: cursor, gemini, codex, copilot, opencode
 
 # 3. Set a goal and go
 taskwing goal "Add Stripe billing"
-# → Plan decomposed into 5 executable tasks
+# -> Plan decomposed into 5 executable tasks
 
 # 4. Execute with your AI assistant
 /taskwing:next       # Get next task with full context
@@ -77,6 +77,32 @@ taskwing goal "Add Stripe billing"
 ```
 
 That's it. Your AI assistant now has persistent architectural context across every session.
+
+## Private by Architecture
+
+TaskWing keeps your knowledge base on your machine. No cloud database, no account, no sync.
+
+```
+                          ┌─────────────────────────────┐
+  1. Bootstrap            │  Your chosen LLM provider    │
+     (one-time)           │  (or Ollama for full local)  │
+                          └──────────────┬──────────────┘
+                                         │ analyze
+                                         v
+                          ┌─────────────────────────────┐
+  2. Store                │  Local SQLite on your machine │
+     (permanent)          │  .taskwing/memory/memory.db  │
+                          └──────────────┬──────────────┘
+                                         │ query (local stdio)
+                                         v
+                          ┌─────────────────────────────┐
+  3. Query                │  Claude, Cursor, Copilot,    │
+     (every session)      │  Gemini, Codex, OpenCode     │
+                          └─────────────────────────────┘
+                          Nothing leaves your machine. ──┘
+```
+
+During initial analysis, code context is processed by your chosen LLM provider. After that, your knowledge base is entirely local. Want full air-gap? Use [Ollama](https://ollama.com/) -- zero network calls, zero external dependencies.
 
 ## Works With
 
@@ -107,12 +133,12 @@ Brand names and logos are trademarks of their respective owners; usage here indi
 
 | Capability | Description |
 |:-----------|:------------|
-| **Memory** | Extracts and persists architectural decisions, patterns, and constraints |
-| **Planning** | Turns a goal into an executable plan with decomposed tasks |
-| **Task Execution** | AI-driven task lifecycle — next, start, complete, verify |
-| **Code Intelligence** | Symbol search, call graphs, impact analysis, simplification |
-| **Debugging** | AI-powered root cause analysis with systematic diagnosis |
-| **MCP Integration** | Exposes everything to your AI tools via Model Context Protocol |
+| **Local knowledge** | Extracts decisions, patterns, and constraints into local SQLite |
+| **Goal to tasks** | Turns a goal into an executable plan with decomposed tasks |
+| **AI-driven lifecycle** | Task execution -- next, start, complete, verify |
+| **Code analysis** | Symbol search, call graphs, impact analysis, simplification |
+| **Root cause first** | AI-powered diagnosis before proposing fixes |
+| **Works everywhere** | Exposes everything to 6+ AI tools via local MCP |
 
 ## Slash Commands
 
@@ -172,8 +198,8 @@ taskwing hook status            # View current session state
 ```
 
 **Circuit breakers** prevent runaway execution:
-- `--max-tasks=5` — Stop after N tasks for human review
-- `--max-minutes=30` — Stop after N minutes
+- `--max-tasks=5` -- Stop after N tasks for human review
+- `--max-minutes=30` -- Stop after N minutes
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ taskwing goal "Add Stripe billing"
 /taskwing:done       # Mark complete, advance to next
 ```
 
-That's it. Your AI assistant now has persistent architectural context across every session.
+That's it. Your AI assistant now has local architectural context across every session.
 
 ## Private by Architecture
 

--- a/README.md
+++ b/README.md
@@ -83,23 +83,48 @@ That's it. Your AI assistant now has persistent architectural context across eve
 TaskWing keeps your knowledge base on your machine. No cloud database, no account, no sync.
 
 ```
-  1. Bootstrap            Your chosen LLM provider analyzes your code.
-     (one-time)           Cloud: OpenAI, Anthropic, Google, Bedrock
-                          Local: Ollama (nothing leaves your machine)
+  YOUR MACHINE                          EXTERNAL
+  ─────────────────────────────────     ─────────────────────────
+                                        ┌───────────────────────┐
+  ┌──────────────┐   code context       │ LLM Provider          │
+  │ Your codebase ├────────────────────>│ (OpenAI, Anthropic,   │
+  └──────────────┘   (bootstrap only)   │  Google, Bedrock)     │
+         │                              └───────────┬───────────┘
+         │                                          │ findings
+         v                                          │
+  ┌──────────────────────┐  <───────────────────────┘
+  │ .taskwing/memory.db  │
+  │ Local SQLite         │  Your knowledge base.
+  │ Never uploaded.      │  Never leaves your machine.
+  └──────────┬───────────┘
+             │ local stdio (MCP)
+             v
+  ┌──────────────────────┐              ┌───────────────────────┐
+  │ AI Tool              │  may send    │ Tool's own cloud      │
+  │ (Claude, Cursor,     ├─────────────>│ (per their privacy    │
+  │  Copilot, Gemini)    │  to their    │  policy)              │
+  └──────────────────────┘  servers     └───────────────────────┘
 
-  2. Store                Local SQLite on your filesystem.
-     (permanent)          .taskwing/memory/memory.db
-                          Never uploaded. Never synced.
 
-  3. Query                MCP responses served over local stdio.
-     (every session)      Your AI tool receives context locally.
+  FULL AIR-GAP (everything stays left of the line):
+
+  ┌──────────────┐        ┌─────────┐        ┌──────────────┐
+  │ Your codebase ├──────>│ Ollama  ├──────>│ .taskwing/   │
+  └──────────────┘        │ (local) │        │ memory.db    │
+                          └─────────┘        └──────┬───────┘
+                                                    │ local stdio
+                                                    v
+                                             ┌──────────────┐
+                                             │ Local AI tool │
+                                             └──────────────┘
+                                             Zero network calls.
 ```
 
-**What TaskWing controls:** Your knowledge base is stored and queried locally. MCP queries never touch the network.
+**What TaskWing controls:** Your knowledge base is stored and queried locally. MCP serves responses over local stdio -- no network calls.
 
-**What your AI tool controls:** Cloud-based tools (Claude, Cursor, Copilot) send conversations to their own servers per their privacy policies. To keep queries fully local, use Ollama for both bootstrap and your AI tool.
+**What your AI tool controls:** Cloud-based tools (Claude, Cursor, Copilot) may send conversations to their own servers. Check their privacy settings (e.g., Cursor's Privacy Mode, Copilot's data retention policies).
 
-**Full air-gap:** Use [Ollama](https://ollama.com/) for bootstrap + a local AI tool. Zero network calls, zero external dependencies, zero data leaving your machine.
+**Full air-gap:** Use [Ollama](https://ollama.com/) for bootstrap + a local AI tool. Nothing leaves your machine.
 
 ## Works With
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Without TaskWing              With TaskWing
 8-12 file reads               1 MCP query
 ~25,000 tokens                ~1,500 tokens
 2-3 minutes                   42 seconds
-Zero persistent context       170+ knowledge nodes
+No architectural context       170+ knowledge nodes
 ```
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -83,26 +83,23 @@ That's it. Your AI assistant now has persistent architectural context across eve
 TaskWing keeps your knowledge base on your machine. No cloud database, no account, no sync.
 
 ```
-                          ┌─────────────────────────────┐
-  1. Bootstrap            │  Your chosen LLM provider    │
-     (one-time)           │  (or Ollama for full local)  │
-                          └──────────────┬──────────────┘
-                                         │ analyze
-                                         v
-                          ┌─────────────────────────────┐
-  2. Store                │  Local SQLite on your machine │
-     (permanent)          │  .taskwing/memory/memory.db  │
-                          └──────────────┬──────────────┘
-                                         │ query (local stdio)
-                                         v
-                          ┌─────────────────────────────┐
-  3. Query                │  Claude, Cursor, Copilot,    │
-     (every session)      │  Gemini, Codex, OpenCode     │
-                          └─────────────────────────────┘
-                          Nothing leaves your machine. ──┘
+  1. Bootstrap            Your chosen LLM provider analyzes your code.
+     (one-time)           Cloud: OpenAI, Anthropic, Google, Bedrock
+                          Local: Ollama (nothing leaves your machine)
+
+  2. Store                Local SQLite on your filesystem.
+     (permanent)          .taskwing/memory/memory.db
+                          Never uploaded. Never synced.
+
+  3. Query                MCP responses served over local stdio.
+     (every session)      Your AI tool receives context locally.
 ```
 
-During initial analysis, code context is processed by your chosen LLM provider. After that, your knowledge base is entirely local. Want full air-gap? Use [Ollama](https://ollama.com/) -- zero network calls, zero external dependencies.
+**What TaskWing controls:** Your knowledge base is stored and queried locally. MCP queries never touch the network.
+
+**What your AI tool controls:** Cloud-based tools (Claude, Cursor, Copilot) send conversations to their own servers per their privacy policies. To keep queries fully local, use Ollama for both bootstrap and your AI tool.
+
+**Full air-gap:** Use [Ollama](https://ollama.com/) for bootstrap + a local AI tool. Zero network calls, zero external dependencies, zero data leaving your machine.
 
 ## Works With
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,11 +51,9 @@ var (
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "taskwing",
-	Short: "TaskWing helps turn a goal into executed tasks with persistent context across AI sessions.",
-	Long: `TaskWing helps turn a goal into executed tasks with persistent context across AI sessions.
-
-Create a plan, execute tasks with your AI tool, and keep architecture context
-persistent across sessions.`,
+	Short: "Local-first AI knowledge layer for development.",
+	Long: `TaskWing extracts architectural knowledge from your codebase and stores it locally.
+Every AI tool gets instant context via MCP, without your knowledge base leaving your machine.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if err := initTelemetry(cmd, args); err != nil {
 			return err

--- a/docs/PRODUCT_VISION.md
+++ b/docs/PRODUCT_VISION.md
@@ -6,7 +6,7 @@ TaskWing extracts architectural knowledge from codebases and stores it locally, 
 
 **TaskWing is the local-first knowledge layer for AI-assisted development.**
 
-We extract your architecture -- decisions, patterns, constraints -- into a local SQLite database. Every AI tool gets instant context via MCP, without your codebase flowing through someone else's cloud.
+We extract your architecture -- decisions, patterns, constraints -- into a local SQLite database. Every AI tool gets instant context via MCP, without your knowledge base leaving your machine.
 
 ## Private by Architecture
 

--- a/docs/PRODUCT_VISION.md
+++ b/docs/PRODUCT_VISION.md
@@ -1,12 +1,25 @@
-# TaskWing: AI-Native Task Management
+# TaskWing: Local-First AI Knowledge Layer
 
-TaskWing helps turn a goal into executed tasks with persistent context across AI sessions.
+TaskWing extracts architectural knowledge from codebases and stores it locally, giving every AI coding tool instant context without your knowledge base leaving your machine.
 
 ## Vision Statement
 
-**TaskWing is AI-native task management that actually understands your codebase.**
+**TaskWing is the local-first knowledge layer for AI-assisted development.**
 
-We don't just store tasks. We generate context-aware development plans by analyzing your architecture, patterns, and decisions.
+We extract your architecture -- decisions, patterns, constraints -- into a local SQLite database. Every AI tool gets instant context via MCP, without your codebase flowing through someone else's cloud.
+
+## Private by Architecture
+
+| Property | How |
+|----------|-----|
+| Knowledge stored locally | SQLite on your filesystem. No cloud database, no sync. |
+| No account required | Install via brew and use immediately. Zero data collection surface. |
+| AI tools connect locally | MCP queries served over local stdio. No network calls for queries. |
+| Air-gappable | Ollama support for fully offline operation. Zero external dependencies. |
+| Open source (MIT) | Audit every line. Fork it. Run it on your own terms. |
+| No vendor kill switch | MIT license, SQLite storage, standard MCP protocol. |
+
+During initial analysis, code context is processed by your chosen LLM provider (OpenAI, Anthropic, Google, Bedrock, or fully local via Ollama). After extraction, your knowledge base is entirely local.
 
 ## Ecosystem Support
 
@@ -43,22 +56,24 @@ Brand names and logos are trademarks of their respective owners; usage here indi
 │  taskwing goal "..."  │  /taskwing:next  │  /taskwing:done   │
 └─────────────────────────────────────────────────────────┘
                               │
-                              ▼
+                              v
 ┌─────────────────────────────────────────────────────────┐
 │                   TASK GENERATION                        │
-│  Analyze goal → Query knowledge graph → Generate tasks   │
+│  Analyze goal -> Query knowledge graph -> Generate tasks │
 └─────────────────────────────────────────────────────────┘
                               │
-                              ▼
+                              v
 ┌─────────────────────────────────────────────────────────┐
-│               KNOWLEDGE GRAPH (The Moat)                 │
+│            LOCAL KNOWLEDGE GRAPH (The Moat)              │
 │  Features │ Patterns │ Decisions │ Constraints │ Files  │
+│            Stored in local SQLite -- never synced        │
 └─────────────────────────────────────────────────────────┘
                               │
-                              ▼
+                              v
 ┌─────────────────────────────────────────────────────────┐
-│                    MCP SERVER                            │
-│  Claude │ Cursor │ Copilot │ Codex — all get context    │
+│                 LOCAL MCP SERVER (stdio)                  │
+│  Claude │ Cursor │ Copilot │ Codex -- all get context   │
+│            No network calls for queries                  │
 └─────────────────────────────────────────────────────────┘
 ```
 
@@ -105,4 +120,4 @@ Brand names and logos are trademarks of their respective owners; usage here indi
 | Team        | $29/seat/mo | Shared knowledge graph, team sync |
 | Enterprise  | Custom      | SSO, audit, on-prem               |
 
-_The knowledge graph is the moat. Task management is the product._
+_The local knowledge graph is the moat. AI-assisted development is the product._

--- a/docs/PRODUCT_VISION.md
+++ b/docs/PRODUCT_VISION.md
@@ -19,7 +19,9 @@ We extract your architecture -- decisions, patterns, constraints -- into a local
 | Open source (MIT) | Audit every line. Fork it. Run it on your own terms. |
 | No vendor kill switch | MIT license, SQLite storage, standard MCP protocol. |
 
-During initial analysis, code context is processed by your chosen LLM provider (OpenAI, Anthropic, Google, Bedrock, or fully local via Ollama). After extraction, your knowledge base is entirely local.
+**What TaskWing controls:** During bootstrap, code context is processed by your chosen LLM provider (cloud or Ollama for full local). After extraction, your knowledge base is stored and queried locally. MCP responses are served over local stdio and never touch the network.
+
+**What your AI tool controls:** Cloud-based AI tools (Claude, Cursor, Copilot) send conversations -- including TaskWing's MCP responses -- to their own servers per their privacy policies. TaskWing cannot control this. To keep everything local, use Ollama for bootstrap and a local AI tool for queries.
 
 ## Ecosystem Support
 

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -1,6 +1,6 @@
 # TaskWing Tutorial
 
-TaskWing helps you move from one goal to executed tasks while keeping architecture context persistent across AI sessions.
+TaskWing extracts architectural knowledge from your codebase and stores it locally, giving every AI tool instant context via MCP.
 
 ## Supported Models
 

--- a/docs/positioning/freshness-validation-plan.md
+++ b/docs/positioning/freshness-validation-plan.md
@@ -1,0 +1,161 @@
+# Query-Time Freshness Validation - Implementation Plan
+
+**Date:** 2026-03-15
+**Status:** Planned
+
+## Problem
+
+After bootstrap, TaskWing's knowledge graph goes stale as the codebase changes.
+Day 1: 170 accurate nodes. Day 30: half describe code that no longer exists.
+No hooks, no daemons, no cron -- validate freshness at query time, the exact
+moment it matters.
+
+## Design
+
+Every MCP query validates the findings it's about to return:
+
+```
+MCP query -> find matching nodes -> stat() evidence files -> adjust confidence -> return with freshness metadata
+```
+
+Three levels:
+- **Level 1**: stat() mtime check (always, inline, <1ms per node)
+- **Level 2**: re-read changed files, check if snippets still exist (only on stale files, 1-5ms)
+- **Level 3**: queue for full re-analysis (async, background)
+
+## Coverage
+
+| Scenario | Covered? |
+|----------|----------|
+| Uncommitted WIP changes | Yes (mtime changes on save) |
+| Mid-session refactoring | Yes (every query re-checks) |
+| Overnight team changes | Yes (first query catches it) |
+| Branch switches | Yes (files change, mtimes change) |
+| No git at all | Yes (uses filesystem, not git) |
+| Long sessions | Yes (every query is a checkpoint) |
+
+Estimated coverage: ~95%. Only gap: semantic changes in OTHER files that
+invalidate a finding whose own file didn't change.
+
+## Schema Changes
+
+Add to `nodes` table:
+
+```sql
+ALTER TABLE nodes ADD COLUMN last_verified_at TEXT;
+ALTER TABLE nodes ADD COLUMN last_verified_level INTEGER DEFAULT 0;
+ALTER TABLE nodes ADD COLUMN original_confidence REAL;
+```
+
+Uses existing `migrateAddColumn` pattern. NULL = never checked = stale on first query.
+
+## Type Changes
+
+### Node struct (internal/memory/models.go)
+
+```go
+LastVerifiedAt     *time.Time  // When last freshness check ran
+LastVerifiedLevel  int         // 0=never, 1=stat, 2=snippet, 3=full
+OriginalConfidence *float64    // Confidence at ingest, before decay
+```
+
+### NodeResponse (internal/knowledge/response.go)
+
+```go
+FreshnessStatus string   // "fresh", "stale", "missing", "no_evidence"
+FreshnessAge    string   // "2h ago", "3d ago"
+StaleFiles      []string // Which evidence files changed
+```
+
+## Integration Point
+
+Single hook in `internal/app/ask.go` at end of `Query()`. All MCP tools
+that consume knowledge (ask, code, debug) go through this path.
+
+```go
+if a.ctx.BasePath != "" {
+    freshness.ValidateNodeResponses(ctx, a.ctx.Repo, a.ctx.BasePath, result.Results)
+}
+```
+
+## Confidence Adjustment
+
+Multiplicative decay with floor of 0.1:
+
+| Condition | Decay Factor |
+|-----------|-------------|
+| All evidence files unchanged | 1.0 |
+| Some files changed, snippets still present (Level 2) | 0.95 |
+| Some files changed, snippets moved | 0.85 |
+| Some files changed, snippets gone | 0.7 |
+| Evidence file deleted | 0.4 |
+| All evidence deleted | 0.2 |
+
+`adjustedConfidence = originalConfidence * decayFactor` (never below 0.1)
+
+## Edge Cases
+
+| Edge Case | Handling |
+|-----------|---------|
+| Relative paths | Always resolve against project root via filepath.Join(basePath, path) |
+| Deleted files | Mark as "missing", decay 0.4. Distinct from "contradicted". |
+| Moved files (git mv) | stat() fails. Future: grep_pattern fallback. For now: mark as missing. |
+| No evidence | Return "no_evidence" status. Exempt from freshness checks. |
+| Build artifacts (dist/, node_modules/) | Skip list of path patterns. Don't decay for generated file changes. |
+| Large files (>1MB) | Level 1 always. Level 2 skipped (snippet matching too slow). |
+| Permission errors | Return "inaccessible". Don't decay confidence. |
+| Network mounts | 100ms timeout per stat(). Return "unknown" on timeout. |
+| Clock skew | Compare mtime deltas (current stat vs stored stat), not absolute times. |
+
+## MCP Response Format
+
+```
+1. **JWT Authentication** (decision) [verified 2h ago]
+   Uses RS256 with key rotation...
+
+2. **Session Middleware** (pattern) [STALE: auth/session.go changed]
+   Express middleware for session management...
+   Confidence: 0.63 (adjusted from 0.9 for stale evidence)
+
+3. **OAuth2 Provider** (decision) [WARNING: evidence file deleted]
+   Google OAuth2 integration...
+   Confidence: 0.18 (evidence no longer exists)
+```
+
+## New Files
+
+| File | Lines (est.) | Purpose |
+|------|-------------|---------|
+| `internal/freshness/validate.go` | ~120 | Level 1 + Level 2 validation |
+| `internal/freshness/cache.go` | ~60 | In-memory stat cache (60s TTL) |
+| `internal/freshness/queue.go` | ~50 | Level 3 reanalysis queue |
+| `internal/freshness/skip.go` | ~30 | Build artifact skip patterns |
+
+## Modified Files
+
+| File | Change |
+|------|--------|
+| `internal/memory/models.go` | Add 3 freshness fields to Node |
+| `internal/memory/sqlite.go` | Migration + update SELECT/INSERT/UPDATE |
+| `internal/knowledge/response.go` | Add freshness fields to NodeResponse |
+| `internal/mcp/presenter.go` | Render freshness in markdown |
+| `internal/app/ask.go` | Hook freshness validation into Query() |
+
+## Ship Order
+
+| Level | What | Effort | Ship |
+|-------|------|--------|------|
+| 1 | stat() mtime check + confidence decay + response metadata | 2 days | v1.22.0 |
+| 2 | Snippet re-validation on stale files | 1 day | v1.22.0 |
+| 3 | Async reanalysis queue + bootstrap --incremental integration | 2 days | v1.23.0 |
+
+## Performance Budget
+
+| Level | Per-node | 5-node query | When |
+|-------|---------|-------------|------|
+| 1 | ~100us | ~1.5ms | Always |
+| 2 | ~1-5ms | ~5-15ms | Only stale |
+| 3 | ~2-10s | N/A | Async/background |
+
+Optimization: 60-second in-memory stat cache to avoid re-statting same files
+across multiple queries in a session.

--- a/docs/positioning/multi-agent-bootstrap-plan.md
+++ b/docs/positioning/multi-agent-bootstrap-plan.md
@@ -1,0 +1,172 @@
+# Multi-Agent Bootstrap Pipeline - Implementation Plan
+
+**Date:** 2026-03-15
+**Status:** Planned
+**Target:** v1.22.0 (Phase 1), v1.23.0 (Phase 2), v1.24.0 (Phase 3)
+
+## Overview
+
+Add 4 internal post-processing agents to the bootstrap pipeline that cross-validate,
+refine, and synthesize findings. Users run `taskwing bootstrap` and get better output.
+No user-facing configuration. Invisible quality improvement.
+
+## Current Pipeline
+
+```
+DocAgent ──┐
+CodeAgent ─┤──→ aggregate ──→ verify evidence ──→ deduplicate ──→ store
+GitAgent  ─┤
+DepsAgent ─┘
+```
+
+## New Pipeline
+
+```
+DocAgent ──┐
+CodeAgent ─┤──→ aggregate ──→ verify evidence ──→ deduplicate
+GitAgent  ─┤
+DepsAgent ─┘
+              ──→ CrossChecker (find contradictions)
+              ──→ CoverageAuditor (find gaps, re-extract)
+              ──→ Refiner (sharpen vague findings)
+              ──→ Synthesizer (produce architecture narrative)
+              ──→ store
+```
+
+Each phase is independently skippable on failure (graceful degradation).
+No backward compatibility flag. Post-processing is always on. No --skip-postprocess.
+
+---
+
+## Agent Roster
+
+### 1. Synthesizer
+- **Role:** Produce coherent architecture narrative from all findings
+- **Input:** All verified findings + project metadata
+- **Output:** ArchitectureSummary node (overview, style, decisions, data flow, risks)
+- **Model:** User's configured model. Ollama 14B+ recommended.
+- **Ship:** v1.22.0
+
+### 2. CrossChecker
+- **Role:** Find contradictions between agent findings
+- **Input:** All findings grouped by source agent
+- **Output:** Contradiction list + unsupported claims. Confidence adjustments.
+- **Model:** Works on 7B local models. Structured comparison task.
+- **Ship:** v1.22.0
+
+### 3. Refiner
+- **Role:** Sharpen vague/low-confidence findings using actual source code
+- **Input:** Findings with confidence < 0.8 + contradicted findings + source code
+- **Output:** Revised findings with updated descriptions and confidence
+- **Model:** Needs strong model. 14B+ local, Sonnet/GPT-4o-mini cloud.
+- **Ship:** v1.23.0
+
+### 4. CoverageAuditor
+- **Role:** Find important unanalyzed code areas, trigger re-extraction
+- **Input:** File tree + covered files set
+- **Output:** Top 5 coverage gaps. Re-runs CodeAgent on top 3.
+- **Model:** Simplest task. 7B works fine.
+- **Ship:** v1.24.0
+
+---
+
+## Package Structure
+
+```
+internal/agents/postprocess/     -- NEW PACKAGE
+  postprocess.go                 -- Pipeline orchestrator
+  context.go                     -- Shared state between phases
+  cross_checker.go               -- CrossChecker agent
+  coverage_auditor.go            -- CoverageAuditor agent
+  refiner.go                     -- Refiner agent
+  synthesizer.go                 -- Synthesizer agent
+  prompts.go                     -- Prompt templates
+```
+
+Modified files:
+- `internal/agents/core/types.go` -- add Contradiction, CoverageGap, UnsupportedClaim, ArchitectureSummary
+- `internal/bootstrap/service.go` -- insert pipeline call between verification and ingestion
+
+---
+
+## Communication Protocol
+
+Agents share state via `postprocess.Context` (passed by pointer):
+- Each agent reads what it needs, writes its output
+- No agent-to-agent messaging
+- FinalFindings() method applies all refinements and removals
+
+Each agent gets minimal context:
+- CrossChecker: all findings grouped by agent
+- CoverageAuditor: file tree + covered files set
+- Refiner: only low-confidence + contradicted findings + source code
+- Synthesizer: all final findings
+
+---
+
+## Prompt Architecture
+
+Key techniques:
+- **CrossChecker**: "You MUST identify at least 3 items" (prevents "looks good")
+- **CoverageAuditor**: Contrast file tree vs covered files (simple pattern matching)
+- **Refiner**: "You may NOT leave any finding unchanged" (forces actual review)
+- **Synthesizer**: "Every sentence must reference a specific file path" (prevents generic output)
+
+---
+
+## Model Strategy
+
+| Agent | Min Local | Recommended Local | Cloud |
+|-------|----------|-------------------|-------|
+| CrossChecker | 7B | Qwen 2.5 14B | Haiku |
+| CoverageAuditor | 7B | Qwen 2.5 7B | Haiku |
+| Refiner | 14B | Qwen 2.5 32B | Sonnet |
+| Synthesizer | 14B | Qwen 2.5 32B | Sonnet |
+
+Principle: never make cloud calls the user didn't configure. If Ollama, everything local.
+
+---
+
+## Failure Modes
+
+Each phase has:
+- 90-second timeout (local) / 30-second timeout (cloud)
+- JSON parse retry (2 attempts with repair)
+- Graceful skip on failure (next phase runs with unmodified findings)
+- Phase results logged for debugging
+
+Degradation order: Full -> no narrative -> no gaps -> no refinement -> no cross-check
+
+Safeguards:
+- Refiner: cap removals at 20% of total findings
+- CrossChecker: cap confidence reduction at 0.2 per finding
+- CoverageAuditor: re-extract top 3 gaps only, 60s timeout
+- Synthesizer: require >5 file paths in output or skip
+
+---
+
+## Ship Schedule
+
+| Week | Deliverable | Version |
+|------|-------------|---------|
+| Week 1 | Pipeline + Synthesizer + CrossChecker | dev |
+| Week 2 | Testing, prompt tuning, Ollama validation | dev |
+| Week 2 end | **v1.22.0** release | v1.22.0 |
+| Week 3 | Refiner + testing | dev |
+| Week 3 end | **v1.23.0** release | v1.23.0 |
+| Week 4 | CoverageAuditor + testing | dev |
+| Week 4 end | **v1.24.0** release | v1.24.0 |
+
+---
+
+## Success Metrics
+
+| Metric | Current | Target |
+|--------|---------|--------|
+| Architecture summary exists | No | Yes, with >5 file refs |
+| Contradictions detected | 0 | >1 per repo with doc drift |
+| Avg finding confidence | ~0.72 | >0.80 after refinement |
+| File coverage | ~35-50% | >65% after gap-fill |
+| Bootstrap Quality Score | ~0.50 | >0.75 |
+
+BQS = (0.3 * coverage) + (0.3 * avgConfidence) + (0.2 * (1 - contradictionRate)) + (0.2 * hasSummary)

--- a/docs/positioning/phase-1-messaging-framework.md
+++ b/docs/positioning/phase-1-messaging-framework.md
@@ -1,0 +1,93 @@
+# Phase 1: Strategic Positioning & Messaging Framework
+
+**Date:** 2026-03-14
+**Status:** Complete
+
+## Core Narrative Angle
+
+AI coding tools are powerful but architecturally reckless -- they vacuum up your codebase context and send it to cloud services you don't control. TaskWing takes the opposite approach: extract your architecture once, store it locally, and give every AI tool instant context without surrendering your intellectual property.
+
+Speed and control aren't competing values -- TaskWing delivers both because local queries are inherently faster AND more private.
+
+**One-liner candidates:**
+
+- "AI context that stays on your machine."
+- "Your architecture. Your machine. Every AI tool."
+- "The local-first knowledge layer for AI development."
+
+## Five Credible Sovereignty Claims
+
+| # | Claim | Scope / Honest Boundary |
+|---|-------|------------------------|
+| 1 | **Your knowledge base is 100% local** -- stored in SQLite on your filesystem, no cloud sync, no account | Fully true. The extracted knowledge (decisions, patterns, constraints) never leaves the machine. |
+| 2 | **No signup, no telemetry by default** -- install and use with zero data collection | True. Telemetry is opt-in with explicit consent prompt. |
+| 3 | **AI tools connect locally via MCP** -- context flows over local stdio, not cloud APIs | True. The MCP server runs locally; AI tools query it over stdin/stdout. |
+| 4 | **Fully air-gappable with Ollama** -- bootstrap + query with zero external network calls | True but requires Ollama setup. This is the only config where *nothing* leaves the machine. Worth promoting explicitly. |
+| 5 | **Open source (MIT)** -- audit the code, fork it, run it on your own terms | True. No "open core" bait-and-switch. |
+
+**Claim you must NOT make:**
+"Your code never leaves your machine." During bootstrap with cloud LLM providers, code context IS sent to the API. The correct framing: *"During initial analysis, code context is processed by your chosen LLM provider. After that, your knowledge base is entirely local."*
+
+## Messaging Hierarchy
+
+### Primary Message
+**"AI context that never leaves your machine."**
+
+### Secondary Messages
+
+| Message | Audience | When to use |
+|---------|----------|-------------|
+| "90% fewer tokens. 75% faster. Zero cloud dependency." | Developers | README hero, landing page metrics section |
+| "Your architectural knowledge stays on your infrastructure." | Engineering leads, CTOs | Enterprise landing page, sales conversations |
+| "Works with Claude, Cursor, Copilot, Gemini -- without sending your codebase to another cloud." | Developers evaluating tools | Comparison pages, "Works With" section |
+| "Fully air-gappable with Ollama for classified and regulated environments." | Gov/defense/healthcare | Dedicated sovereignty page, enterprise docs |
+
+### Supporting Proof Points
+- Local SQLite storage (no cloud database)
+- MIT open source (auditable)
+- No account required (no data collection surface)
+- MCP over local stdio (no network calls for queries)
+- Supports Ollama (full air-gap option)
+
+## Words & Phrases
+
+### Adopt
+
+| Phrase | Why |
+|--------|-----|
+| "local-first" | Developer community understands this instantly. Signals architectural intent. |
+| "your machine" / "your infrastructure" | Concrete. Avoids abstract "sovereignty" jargon. |
+| "zero cloud dependency" (for queries) | Specific, verifiable, differentiating. |
+| "air-gappable" | Signals seriousness to gov/defense/enterprise. |
+| "knowledge layer" | Better than "memory" -- implies structure, not just recall. |
+| "private by architecture" | Stronger than "private by policy." Architecture can be audited. |
+
+### Retire
+
+| Phrase | Why |
+|--------|-----|
+| "persistent memory" | Sounds like a database feature. Undersells sovereignty. |
+| "AI task manager" | Commodity framing. Every PM tool claims AI now. |
+| "control plane" | Infrastructure jargon meaningless to most developers. |
+| "a brain" (as primary) | Vague. Doesn't differentiate. Keep only as secondary/playful. |
+| "data sovereignty" (in dev copy) | Too formal for developers. Use "local-first" instead. Reserve for enterprise/gov. |
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Bootstrap sends code to LLM APIs | High | Be transparent upfront. Promote Ollama for full air-gap. |
+| "Sovereignty" sounds enterprise-washy | Medium | Use "local-first" and "your machine" for devs. Reserve "sovereignty" for enterprise page. |
+| No SOC 2 or compliance certs | Medium | Position as "private by architecture" -- nothing to comply about. |
+| Ollama quality gap vs cloud LLMs | Low | Frame Ollama as air-gap option, not recommended default. |
+| Competitors add local mode | Medium | Ship the story now. First-mover in positioning matters. |
+
+## Recommendation: Dual-Track (Option C)
+
+- **Developer-facing** (README, landing hero): Lead with productivity, embed local-first in same breath.
+- **Enterprise/gov-facing** (dedicated page, LinkedIn, sales): Lead with sovereignty.
+
+### Proposed README Hero
+
+> Your AI tools start every session from zero -- and every session, your code context flows through someone else's cloud.
+> TaskWing takes the opposite approach. One command extracts your architecture into a local knowledge base on your machine. No cloud. No account. Every AI session after that just *knows* -- without your codebase leaving your infrastructure.

--- a/docs/positioning/phase-2-market-validation.md
+++ b/docs/positioning/phase-2-market-validation.md
@@ -1,0 +1,122 @@
+# Phase 2: Market Research & Audience Validation
+
+**Date:** 2026-03-14
+**Status:** Complete
+
+## Hard Truth
+
+**TaskWing is not the only local-first AI dev tool. Cline ($32M Series A) and Continue.dev ($5.1M) are already positioning hard on privacy/sovereignty for enterprise.** The window to own "local-first AI knowledge layer" is open but closing. The differentiation is not "local" (others have that) -- it's **structured knowledge extraction + local storage + multi-tool MCP access**. No competitor combines all three.
+
+## 1. Who Cares About Sovereignty in Dev Tools
+
+Ranked by revealed purchasing behavior, not stated preference:
+
+| Segment | Urgency | Evidence | Action for TaskWing |
+|---------|---------|----------|---------------------|
+| **Government/defense contractors** | Highest | Air-gap requirements are hard blockers, not preferences. Windsurf pursued FedRAMP. Cline's $32M raise targets "enterprises that trust." | Ollama path must be prominent. "Air-gappable" is the keyword. |
+| **Healthcare/fintech (regulated)** | High | HIPAA, PCI-DSS, SOX create legal requirements around code context handling. Continue.dev explicitly targets "healthcare, financial systems." | No SOC 2 yet, but "private by architecture" + open source auditability is a credible interim story. |
+| **Enterprise engineering teams** | High | Gartner: 75% of enterprise devs will use AI code assistants by 2028. Security incidents in AI IDEs (Fortune, late 2025) are accelerating demand for controlled alternatives. | Enterprise page needed. But don't pretend to be enterprise-ready without customers. |
+| **EU/UK teams under GDPR** | Medium-High | EU AI Act GPAI obligations active since Aug 2025. 50 fines totalling EUR 250M by Q1 2026. UK Data (Use and Access) Act 2025 in force. | "Private by architecture" is GDPR-friendly. No data processing agreement needed if no data leaves. |
+| **Startups with IP concerns** | Medium | Pre-acquisition code review scrutinizes third-party data exposure. AI tool usage is now part of due diligence. | Secondary message: "Your IP stays yours." |
+| **Privacy-conscious indie devs** | Low-Medium | Vocal on HN/Reddit but low conversion to paid. Will adopt free tools but rarely drive revenue. | Keep these users happy (they're your evangelists) but don't optimize messaging for them. |
+
+## 2. Terminology Testing
+
+| Term | Developer Appeal | Enterprise Appeal | Recommendation |
+|------|-----------------|-------------------|----------------|
+| **"local-first"** | HIGH -- developers know this term from local-first software movement. Signals architecture, not marketing. | Medium -- understood but may feel too casual for procurement. | **Use in developer copy.** Primary term for README, landing page hero. |
+| **"private by architecture"** | High -- implies structural guarantee, not policy promise. Developers respect this distinction. | HIGH -- distinguishes from "private by policy" (which can change). Auditable. | **Use everywhere.** Works for both audiences. Best single phrase. |
+| **"your machine"** | High -- concrete, tangible, zero abstraction. | Medium -- enterprise prefers "your infrastructure." | **Use in developer copy.** Swap to "your infrastructure" for enterprise. |
+| **"air-gapped"** | Medium -- niche but instantly understood by the right audience. | HIGH -- magic word for gov/defense procurement. | **Use in Ollama-specific copy and enterprise page only.** |
+| **"data sovereignty"** | Low -- feels policy-wonk, not developer-native. | High -- but overused and often meaningless. | **Avoid in developer copy. Use sparingly in enterprise copy, always with specifics.** |
+| **"zero-trust AI development"** | Low-Medium -- "zero trust" is a security buzzword, not a dev tool term. | Medium -- recognized but may invite scrutiny TaskWing can't survive (no formal zero-trust architecture). | **Avoid.** Overpromises. |
+| **"self-hosted AI context"** | Medium -- accurate but boring. | Medium -- accurate but doesn't differentiate from "self-hosted anything." | **Avoid as primary. Use in technical docs.** |
+
+**Winner: "local-first" for developers, "private by architecture" for everyone.**
+
+## 3. Competitor Messaging Audit
+
+### Summary Matrix
+
+| Tool | Privacy Claims | Self-Hosted | Privacy Positioning | Vulnerability |
+|------|--------------|-------------|--------------------|----|
+| **Cursor** | Zero retention in Privacy Mode (opt-in). Default: data collected for training. SOC 2. | No | Secondary | Default-off privacy mode is a liability. "Your code trains their models unless you flip a switch." |
+| **GitHub Copilot** | Business/Enterprise: no training, no retention from IDE. Free tier: different rules. | No | Primary (enterprise) | 28-day retention for CLI access. Complex tier-dependent policies confuse buyers. |
+| **Windsurf** | Zero retention default for teams. SOC 2 Type II. FedRAMP High. | Yes (maintenance mode -- no new customers) | Primary | Self-hosted option killed. Hybrid still exists but signals retreat from on-prem. |
+| **Continue.dev** | "Code never leaves your machine" with local models. Apache 2.0. | Yes, fully | Primary/foundational | **Closest competitor to TaskWing's positioning.** But no structured knowledge extraction -- just a model connector. |
+| **Aider** | Never collects code/keys. Opt-in analytics. | Yes, inherently | Secondary (structural) | No persistent knowledge layer. Each session starts from zero (same problem TaskWing solves). |
+| **Cline** | "Code never leaves your machine." Full audit trail. $32M Series A. | Yes, fully | Primary | **Most dangerous competitor.** Well-funded, explicitly targeting enterprise trust. But no persistent architecture extraction. |
+
+### TaskWing's Unique Position
+
+Nobody else combines:
+1. **Structured knowledge extraction** (not just code context, but decisions, patterns, constraints)
+2. **Local-first storage** (SQLite, no cloud)
+3. **Multi-tool MCP access** (works with 6+ AI tools simultaneously)
+
+Continue.dev and Cline are local but have no persistent knowledge layer.
+Cursor and Copilot have context features but are cloud-dependent.
+Aider is local but starts from zero every session.
+
+**TaskWing's positioning gap to exploit: "Local-first persistent AI knowledge" -- the only tool where your architectural context is both structured AND stays on your machine.**
+
+## 4. Market Timing
+
+### Is "local-first AI dev tools" emerging?
+
+**Yes, and accelerating.**
+
+Evidence:
+- **Cline's $32M raise** (2025) explicitly positioned on "enterprise trust" and open-source auditability
+- **Continue.dev's $5.1M** from YC/Heavybit for "proprietary codebases, healthcare, financial systems"
+- **Windsurf killing self-hosted** creates a vacuum -- enterprises that wanted on-prem have fewer options
+- **Security incidents** (Fortune, late 2025): 30+ security flaws in AI coding IDEs, Amazon Q compromise. These drive enterprise security teams to demand local alternatives.
+- **Cost dynamics**: Self-hosted becomes economically favorable at 50+ developers ($20-35K savings over 5 years)
+
+### Regulatory momentum
+
+**Accelerating, not plateauing.**
+
+- EU AI Act GPAI obligations active since Aug 2025; 50 fines, EUR 250M by Q1 2026
+- UK Data (Use and Access) Act 2025 in force since Jan 2026
+- UK ICO flagging agentic AI privacy concerns, emphasizing data minimization
+- Westminster actively debating technology sovereignty (the Mark Boost article)
+- Regulators "don't accept black boxes" -- audit trails required for automated workflows
+
+### Timing verdict
+
+TaskWing is not too early. The market is forming now. But the window to establish positioning is 12-18 months before well-funded competitors (Cline, Continue) add knowledge extraction features.
+
+## 5. Risk Assessment
+
+### Can a pre-revenue OSS tool credibly claim sovereignty positioning?
+
+**Yes, IF you lead with architecture, not compliance.**
+
+- "Private by architecture" is credible from day one -- it's a code-level claim, auditable via MIT source
+- "SOC 2 compliant" is NOT credible without the cert -- don't imply it
+- Open source is your proof. Link to the specific code paths that keep data local.
+- **Don't claim enterprise-ready. Claim enterprise-auditable.**
+
+### Does sovereignty risk alienating indie devs?
+
+**Not if you lead with speed and embed sovereignty as the "how".**
+
+Bad: "TaskWing: sovereign AI development" (indie devs bounce)
+Good: "90% fewer tokens, 75% faster -- and your code never leaves your machine" (indie devs stay, enterprise devs perk up)
+
+The dual-track approach from Phase 1 is correct. Sovereignty is *why it's fast* (local queries), not a separate value prop.
+
+### The uncanny valley risk
+
+**Real but manageable.**
+
+- Don't build an enterprise sales page with "Contact Sales" if you have no sales team
+- Don't list compliance certs you don't have
+- DO have a `/sovereignty` or `/local-first` page that explains the architecture
+- DO let the open-source community be your enterprise proof (forks, stars, contributions from enterprise devs)
+- The path: indie adoption -> enterprise developer discovers it -> bottom-up enterprise adoption. Sovereignty messaging attracts the enterprise developer without requiring enterprise sales infrastructure.
+
+## Assignment
+
+**Immediate action**: Create a "How TaskWing keeps your data local" section (README or docs) with an architecture diagram showing: bootstrap (LLM API call, configurable) -> SQLite (local) -> MCP queries (local stdio). This is the single most credible sovereignty proof point and costs zero engineering effort.

--- a/docs/positioning/phase-3-copy-recommendations.md
+++ b/docs/positioning/phase-3-copy-recommendations.md
@@ -1,0 +1,133 @@
+# Phase 3: Copy Rewrite Recommendations
+
+**Date:** 2026-03-14
+**Status:** Complete
+**Depends on:** Phase 1 (messaging framework), Phase 2 (market validation)
+
+## Key Decision: Dual-Track Confirmed
+
+Phase 2 validates the dual-track approach:
+- **Developer copy**: Lead with speed, embed local-first as the "how"
+- **Enterprise copy**: Lead with sovereignty, back with architecture
+
+## README Rewrite
+
+### Current Hero
+```
+Your AI tools start every session from zero. They don't know your stack,
+your patterns, or why you chose PostgreSQL over MongoDB.
+
+TaskWing fixes this. One command extracts your architecture into a local
+database. Every AI session after that just knows.
+```
+
+### Proposed Hero (Option A -- Recommended)
+```
+Your AI tools start every session from zero -- and every session, your
+code context flows through someone else's cloud.
+
+TaskWing takes the opposite approach. One command extracts your architecture
+into a local knowledge base on your machine. No cloud. No account. Every AI
+session after that just knows -- without your codebase leaving your infrastructure.
+```
+
+### Proposed Hero (Option B -- Shorter)
+```
+Your AI tools forget everything between sessions. TaskWing doesn't.
+
+One command extracts your architecture into a local SQLite database.
+Every AI tool gets instant context -- without your code leaving your machine.
+```
+
+### Current Tagline
+"Give your AI tools a brain."
+
+### Proposed Taglines (ranked)
+1. "The local-first knowledge layer for AI development."
+2. "AI context that stays on your machine."
+3. "Your architecture. Your machine. Every AI tool."
+4. "Give your AI tools a brain." (keep as secondary/playful -- still good, just not differentiating)
+
+### Current Subtitle
+"Memory, planning, task execution, and project intelligence -- the control plane for AI-native development."
+
+### Proposed Subtitle
+"Local-first architectural knowledge for AI coding tools. Private by architecture."
+
+## New Section: How Your Data Stays Local
+
+Add after Quick Start, before Works With:
+
+```markdown
+## Private by Architecture
+
+TaskWing keeps your knowledge base on your machine. No cloud database,
+no account, no sync.
+
+How it works:
+1. **Bootstrap** -- your code is analyzed by your chosen LLM provider
+   (or fully local via Ollama)
+2. **Store** -- extracted knowledge lives in local SQLite on your filesystem
+3. **Query** -- AI tools connect via local MCP (stdio). Nothing leaves your machine.
+
+Want full air-gap? Use Ollama. Zero network calls, zero external dependencies.
+```
+
+## Landing Page Recommendations
+
+### Hero Section
+- **Headline**: "AI context that stays on your machine."
+- **Subhead**: "One command extracts your architecture. Every AI tool gets instant context. Your code never touches our servers -- we don't have any."
+- **CTA**: `brew install josephgoksu/tap/taskwing`
+
+### Benefits Grid (replace capability table)
+
+| Current | Proposed |
+|---------|----------|
+| Memory | **Local knowledge** -- Decisions, patterns, constraints in local SQLite |
+| Planning | **Goal to tasks** -- Decompose goals into executable plans |
+| Task Execution | **AI-driven lifecycle** -- next, start, complete, verify |
+| Code Intelligence | **Code analysis** -- symbols, call graphs, impact analysis |
+| MCP Integration | **Works everywhere** -- Claude, Cursor, Copilot, Gemini, Codex, OpenCode |
+| Debugging | **Root cause first** -- AI diagnosis before fixes |
+
+### Social Proof / Trust Section
+- "Open source (MIT) -- audit every line"
+- "No account. No cloud. No telemetry by default."
+- "Air-gappable with Ollama for regulated environments"
+- Stars count, if significant
+
+### Comparison Section (new)
+
+```
+                    TaskWing    Cursor    Copilot   Cline
+Knowledge stored    Local       Cloud     Cloud     None
+Persistent context  Yes         Limited   No        No
+Multi-tool support  6+ tools    1         1         1
+Self-hosted         Yes         No        No        Yes
+Air-gappable        Yes         No        No        Yes
+Open source         MIT         No        No        Apache 2.0
+```
+
+## Words to Update Across All Copy
+
+| Find | Replace with |
+|------|-------------|
+| "persistent memory" | "local knowledge base" or "local-first knowledge" |
+| "AI task manager" | "AI development workflow" or omit |
+| "control plane" | "knowledge layer" |
+| "the brain" (when primary) | "local-first knowledge layer" |
+| "extracts into a database" | "extracts into a local SQLite database on your machine" |
+| "MCP integration" | "works with [tool names] via local MCP" |
+
+## Enterprise/Sovereignty Page (Future)
+
+Dedicated `/local-first` or `/enterprise` page:
+
+- **Headline**: "AI-assisted development without surrendering your intellectual property."
+- **Subhead**: "TaskWing stores architectural knowledge in local SQLite. No cloud. No account. Fully auditable. Air-gappable with Ollama."
+- Architecture diagram showing data flow
+- Comparison with cloud-dependent alternatives
+- Compliance-friendly language (without claiming certs you don't have)
+- "Private by architecture, not by policy" messaging
+- Ollama air-gap instructions

--- a/docs/positioning/phase-4-credibility-audit.md
+++ b/docs/positioning/phase-4-credibility-audit.md
@@ -1,0 +1,106 @@
+# Phase 4: Security & Credibility Audit
+
+**Date:** 2026-03-14
+**Status:** Complete
+**Depends on:** Phase 3 (copy recommendations)
+
+## Purpose
+
+Audit every sovereignty/privacy claim in the proposed copy for technical accuracy.
+Flag anything that overpromises. Suggest qualifiers.
+
+## Claim-by-Claim Audit
+
+### Claim 1: "Your knowledge base is 100% local"
+- **Verdict: TRUE**
+- SQLite database lives at `.taskwing/memory/memory.db` on the local filesystem
+- No cloud sync, no remote backup, no phone-home
+- MCP queries are served over local stdio -- no network calls
+- **No qualifier needed**
+
+### Claim 2: "No cloud. No account."
+- **Verdict: TRUE with qualifier**
+- No TaskWing account exists. No registration endpoint. No user database.
+- However: during bootstrap, code context IS sent to an LLM API (OpenAI, Anthropic, Google, Bedrock)
+- **Required qualifier**: "TaskWing has no cloud service and no account system. During initial architecture extraction, code context is processed by your chosen LLM provider according to their data policies. After extraction, all knowledge stays local."
+- **Recommendation**: Add this to a "How it works" section. Don't bury it -- transparency builds more trust than an absolute claim that gets debunked.
+
+### Claim 3: "Every AI session after that just knows -- without your codebase leaving your infrastructure"
+- **Verdict: PARTIALLY TRUE -- needs scoping**
+- After bootstrap, MCP queries ARE fully local (stdio, no network)
+- BUT: `taskwing plan` and `taskwing goal` make LLM API calls, sending plan context to the provider
+- `taskwing debug` and `taskwing code explain` also use LLM APIs
+- **Required qualifier**: Change "without your codebase leaving your infrastructure" to "without your knowledge base leaving your machine." The knowledge BASE is local; some COMMANDS still call LLM APIs.
+- **Alternative**: "Your architectural knowledge stays on your machine. LLM-powered commands use your configured provider."
+
+### Claim 4: "Fully air-gappable with Ollama"
+- **Verdict: TRUE**
+- With Ollama configured, zero external network calls are made
+- Bootstrap, planning, and queries all go through local Ollama
+- **No qualifier needed** (but note: Ollama model quality is lower than cloud providers)
+
+### Claim 5: "Open source (MIT) -- audit every line"
+- **Verdict: TRUE**
+- Full source at github.com/josephgoksu/TaskWing, MIT license
+- No "open core" -- all features in the open repo
+- **No qualifier needed**
+
+### Claim 6: "No telemetry by default"
+- **Verdict: TRUE**
+- Telemetry is opt-in with explicit consent prompt
+- Auto-disabled in CI, non-interactive terminals
+- PostHog analytics only collect: command names, success/failure, duration, OS, CLI version
+- No code, file paths, or personal data collected
+- **No qualifier needed**
+
+### Claim 7: "Private by architecture"
+- **Verdict: CREDIBLE but not absolute**
+- The architecture IS private-by-default for storage and MCP queries
+- But the architecture also includes LLM API calls for bootstrap/plan/debug
+- **Recommendation**: Use "private by architecture" but define what it means: "Your knowledge base is stored locally and queried locally. LLM-powered analysis uses your chosen provider -- including fully local options via Ollama."
+
+## Claims to AVOID
+
+| Claim | Why | Risk |
+|-------|-----|------|
+| "Your code never leaves your machine" | False during bootstrap with cloud LLMs | Immediate credibility loss if called out |
+| "Zero data collection" | Telemetry exists (opt-in). PostHog is a third party. | Technically defensible but easily misread |
+| "GDPR compliant" | No formal DPA, no data protection officer, no DPIA conducted | Legal liability if claimed without basis |
+| "SOC 2" or "enterprise-grade security" | No cert, no formal security audit | Enterprise buyers will verify and find nothing |
+| "End-to-end encrypted" | Data is not encrypted at rest in SQLite by default | Factually wrong |
+
+## Recommended "How It Works" Transparency Section
+
+```
+## How Your Data Flows
+
+1. **Bootstrap** (one-time)
+   Your code context is sent to your configured LLM provider for analysis.
+   - Cloud providers: OpenAI, Anthropic, Google, AWS Bedrock
+   - Fully local: Ollama (zero network calls)
+   Provider data policies apply during this step.
+
+2. **Knowledge Storage** (permanent, local)
+   Extracted architecture (decisions, patterns, constraints) is stored
+   in SQLite on your filesystem. Never synced. Never uploaded.
+
+3. **AI Tool Queries** (ongoing, local)
+   MCP queries from Claude, Cursor, Copilot etc. are served over
+   local stdio. Your knowledge base never leaves your machine.
+
+4. **Planning & Analysis** (on-demand)
+   Commands like `goal`, `plan`, `debug` use your configured LLM.
+   Same provider choice as bootstrap -- including Ollama for air-gap.
+```
+
+## Summary
+
+| Proposed Copy | Accurate? | Action |
+|--------------|-----------|--------|
+| "knowledge base is local" | Yes | Keep |
+| "no cloud, no account" | Yes (for TaskWing itself) | Keep, add LLM provider qualifier |
+| "codebase never leaves your infrastructure" | Overstates | Change to "knowledge base stays local" |
+| "air-gappable with Ollama" | Yes | Keep |
+| "open source, audit every line" | Yes | Keep |
+| "no telemetry by default" | Yes | Keep |
+| "private by architecture" | Credible with definition | Keep, define clearly |

--- a/docs/positioning/phase-4-credibility-audit.md
+++ b/docs/positioning/phase-4-credibility-audit.md
@@ -64,6 +64,7 @@ Flag anything that overpromises. Suggest qualifiers.
 | Claim | Why | Risk |
 |-------|-----|------|
 | "Your code never leaves your machine" | False during bootstrap with cloud LLMs | Immediate credibility loss if called out |
+| "Nothing leaves your machine" (unqualified) | Cloud AI tools send TaskWing's MCP responses to their own servers | Misleading -- TaskWing controls storage/query, not the AI tool's behavior |
 | "Zero data collection" | Telemetry exists (opt-in). PostHog is a third party. | Technically defensible but easily misread |
 | "GDPR compliant" | No formal DPA, no data protection officer, no DPIA conducted | Legal liability if claimed without basis |
 | "SOC 2" or "enterprise-grade security" | No cert, no formal security audit | Enterprise buyers will verify and find nothing |

--- a/docs/positioning/phase-5-seo-alignment.md
+++ b/docs/positioning/phase-5-seo-alignment.md
@@ -1,0 +1,85 @@
+# Phase 5: SEO Alignment
+
+**Date:** 2026-03-14
+**Status:** Complete
+**Depends on:** Phase 3 (copy recommendations)
+
+## Target Keyword Clusters
+
+### Primary (high intent, emerging volume)
+
+| Keyword | Intent | Competition | Notes |
+|---------|--------|-------------|-------|
+| "local-first AI coding tool" | Discovery | Low | Emerging category. TaskWing can own this. |
+| "private AI code assistant" | Discovery | Medium | Cline and Continue.dev compete here. |
+| "AI coding tool that keeps code local" | Discovery | Low | Long-tail, high intent. |
+| "MCP server for AI coding" | Technical | Low | TaskWing is one of few standalone MCP servers. |
+| "air-gapped AI development" | Enterprise | Low | Niche but high-value. Gov/defense audience. |
+
+### Secondary (established volume, higher competition)
+
+| Keyword | Intent | Competition | Notes |
+|---------|--------|-------------|-------|
+| "AI code context" / "AI coding context" | Discovery | Medium | Broad but relevant. |
+| "cursor alternative privacy" | Comparison | Medium | Competitor-adjacent. |
+| "copilot alternative open source" | Comparison | High | High volume, competitive. |
+| "self-hosted AI code assistant" | Discovery | Medium | Continue.dev and Cline rank here. |
+| "AI architecture extraction" | Technical | Low | Unique to TaskWing. Own this entirely. |
+
+### Long-tail (low volume, near-zero competition)
+
+| Keyword | Intent | Notes |
+|---------|--------|-------|
+| "extract architecture decisions from codebase" | Problem-aware | Unique value prop. Blog post target. |
+| "persistent context for AI coding tools" | Problem-aware | Directly addresses the pain. |
+| "SQLite AI knowledge base" | Technical | Differentiator. |
+| "MCP protocol AI development" | Technical | Growing with MCP adoption. |
+| "ollama air-gapped coding" | Enterprise | Niche but zero competition. |
+
+## Metadata Recommendations
+
+### README / GitHub
+- **Repository description**: "Local-first AI knowledge layer. Extract architecture, query from any AI tool via MCP. Private by architecture."
+- **Topics/tags**: `ai`, `mcp`, `local-first`, `developer-tools`, `architecture`, `sqlite`, `cli`, `privacy`, `ollama`, `code-intelligence`
+
+### Landing Page (taskwing.app)
+
+**Title tag**: "TaskWing -- Local-First AI Knowledge Layer for Development"
+**Meta description**: "Extract your codebase architecture into a local SQLite database. Give Claude, Cursor, Copilot, and Gemini instant context via MCP -- without your code leaving your machine."
+
+### Structured Data (JSON-LD)
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "TaskWing",
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "macOS, Linux",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "description": "Local-first AI knowledge layer. Extract architecture from codebases, store in local SQLite, query from any AI tool via MCP.",
+  "keywords": "local-first, AI coding, MCP, architecture extraction, private, SQLite"
+}
+```
+
+## Content Strategy (blog post targets)
+
+| Title | Target Keyword | Type |
+|-------|---------------|------|
+| "Why your AI coding tool shouldn't need your codebase in the cloud" | private AI code assistant | Thought leadership |
+| "How TaskWing extracts 170+ architecture decisions from any codebase" | AI architecture extraction | Product deep-dive |
+| "Local-first AI development: what it means and why it matters" | local-first AI coding tool | Category definition |
+| "Air-gapped AI coding with Ollama and TaskWing" | air-gapped AI development | Tutorial |
+| "Cursor vs TaskWing: cloud context vs local knowledge" | cursor alternative privacy | Comparison |
+| "The MCP protocol: how AI tools share context locally" | MCP server AI coding | Technical explainer |
+
+## Priority Actions
+
+1. **Immediate**: Update GitHub repo description and topics
+2. **This week**: Update landing page title/meta with sovereignty keywords
+3. **This month**: Publish "Why your AI coding tool shouldn't need your codebase in the cloud" blog post
+4. **Ongoing**: Each blog post targets one keyword cluster from above

--- a/docs/positioning/tool-template-system-plan.md
+++ b/docs/positioning/tool-template-system-plan.md
@@ -1,0 +1,134 @@
+# Tool Template System & New MCP Tools - Implementation Plan
+
+**Date:** 2026-03-15
+**Status:** Planned
+
+## Overview
+
+Refactor TaskWing's MCP tools and slash commands from a 6-file-per-tool manual
+registry system to a single-file self-registering pattern. Then add new tools
+using the pattern.
+
+## Naming Convention
+
+No change. Keep current convention:
+- MCP tools: short names (`ask`, `plan`, `code`)
+- Slash commands: namespaced (`/taskwing:ask`, `/taskwing:plan`)
+
+## Final Tool Roster
+
+### MCP Tools (9 total, under 12 cap)
+
+| # | Tool | Actions | Status |
+|---|------|---------|--------|
+| 1 | `ask` | search (default), explain (new) | Existing + expand |
+| 2 | `task` | next, current, start, complete, session (new) | Existing + expand |
+| 3 | `plan` | clarify, decompose, expand, generate, finalize, audit, goal (new) | Existing + expand |
+| 4 | `code` | find, search, explain, callers, impact, simplify, depends (new) | Existing + expand |
+| 5 | `debug` | (unchanged) | Existing |
+| 6 | `remember` | (unchanged) | Existing |
+| 7 | `health` | coverage, contradictions, stale, summary | New (v1.22.0) |
+| 8 | `onboard` | overview, walkthrough, stack | New (v1.23.0) |
+| 9 | `review` | diff, patterns, compliance | New (v1.23.0) |
+
+### Slash Commands (18 total)
+
+**Architecture & Knowledge:**
+- `/taskwing:ask` -> ask search
+- `/taskwing:explain` -> ask explain
+- `/taskwing:remember` -> remember
+- `/taskwing:health` -> health summary
+
+**Planning & Tasks:**
+- `/taskwing:goal` -> plan goal
+- `/taskwing:plan` -> plan clarify
+- `/taskwing:next` -> task next
+- `/taskwing:done` -> task complete
+- `/taskwing:status` -> task current
+
+**Code Intelligence:**
+- `/taskwing:code` -> code find
+- `/taskwing:simplify` -> code simplify
+- `/taskwing:impact` -> code depends
+- `/taskwing:review` -> review diff
+
+**Debugging:**
+- `/taskwing:debug` -> debug
+
+**Onboarding:**
+- `/taskwing:onboard` -> onboard overview
+- `/taskwing:tour` -> onboard walkthrough
+- `/taskwing:stack` -> onboard stack
+
+**Session:**
+- `/taskwing:session` -> task session
+
+## Architecture
+
+### Package Structure
+
+```
+internal/tools/
+    definition.go          -- Tool, Action, SlashMapping, Request, Response
+    registry.go            -- Register(), All(), Get(), AllSlashCommands()
+    dispatch.go            -- Action resolution, input parsing
+    ask/ask.go
+    task/task.go
+    plan/plan.go
+    code/code.go           -- may split into code.go + find.go + impact.go etc
+    debug/debug.go
+    remember/remember.go
+    health/health.go       -- NEW
+    onboard/onboard.go     -- NEW (v1.23.0)
+    review/review.go       -- NEW (v1.23.0)
+```
+
+### How It Works
+
+1. Each tool file has init() that calls tools.Register()
+2. cmd/mcp_server.go imports tool packages for side effects
+3. MCP server loops tools.All() to register handlers
+4. Slash generator uses tools.AllSlashCommands()
+5. Doc generator uses tools.AllMCPTools()
+
+Adding a new tool = create one file + add one import line.
+
+### Key Types
+
+```go
+type Tool struct {
+    Name          string
+    Description   string
+    InputSchema   json.RawMessage
+    Actions       []Action
+    SlashCommands []SlashMapping
+    Handle        func(ctx context.Context, req Request) (Response, error)
+}
+```
+
+## Migration Steps
+
+| Step | What | Effort | Risk |
+|------|------|--------|------|
+| 0 | Create framework (types + registry + dispatch) | 3h | None (additive) |
+| 1 | Migrate `remember` (simplest tool) | 2h | Low |
+| 2 | Wire slash/doc generation to registry | 2h | Medium |
+| 3 | Migrate `ask` + add `explain` action | 4h | Medium |
+| 4 | Migrate `debug` | 1h | Low |
+| 5 | Add `health` tool (new) | 3h | Low |
+| 6 | Migrate `task` + add `session` action | 4h | Medium |
+| 7 | Migrate `plan` + add `goal` action | 4h | Medium |
+| 8 | Migrate `code` + add `depends` action | 6h | High |
+| 9 | Delete old registries and handlers | 2h | Low |
+| 10 | Add `onboard` + `review` tools | 4h each | Low |
+
+Total: ~5 days for migration + 3 new tools.
+
+## Metrics
+
+| Before | After |
+|--------|-------|
+| 6 files to add a tool | 2 files (tool file + import) |
+| 3 registries to sync | 1 registry (tools.All()) |
+| ~2 hours to add a tool | ~30 min |
+| High doc drift risk | Zero (derived from registry) |

--- a/internal/app/ask.go
+++ b/internal/app/ask.go
@@ -2,14 +2,17 @@ package app
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/cloudwego/eino/schema"
 	"github.com/josephgoksu/TaskWing/internal/codeintel"
+	"github.com/josephgoksu/TaskWing/internal/freshness"
 	"github.com/josephgoksu/TaskWing/internal/knowledge"
 	"github.com/josephgoksu/TaskWing/internal/llm"
 	"github.com/josephgoksu/TaskWing/internal/memory"
@@ -308,6 +311,11 @@ func (a *AskApp) Query(ctx context.Context, query string, opts AskOptions) (*Ask
 		}
 	}
 
+	// Validate freshness of returned knowledge nodes
+	if a.ctx.BasePath != "" {
+		annotateResultFreshness(a.ctx.BasePath, results)
+	}
+
 	return &AskResult{
 		Query:          query,
 		RewrittenQuery: rewrittenQuery,
@@ -514,5 +522,55 @@ func suppressStdLogger() func() {
 	log.SetOutput(io.Discard)
 	return func() {
 		log.SetOutput(prev)
+	}
+}
+
+// annotateResultFreshness runs Level 1 freshness checks on each result
+// and populates the FreshnessStatus, FreshnessNote, and StaleFiles fields.
+// This runs inline on every MCP query (<1ms per result).
+func annotateResultFreshness(basePath string, results []knowledge.NodeResponse) {
+	for i := range results {
+		node := &results[i]
+
+		// Reconstruct evidence JSON from the parsed EvidenceRef slice
+		// for the freshness checker
+		if len(node.Evidence) == 0 {
+			node.FreshnessStatus = string(freshness.StatusNoEvidence)
+			continue
+		}
+
+		// Build evidence JSON from EvidenceRef
+		type ev struct {
+			FilePath string `json:"file_path"`
+		}
+		items := make([]ev, len(node.Evidence))
+		for j, e := range node.Evidence {
+			items[j] = ev{FilePath: e.File}
+		}
+		evJSON, err := json.Marshal(items)
+		if err != nil {
+			continue
+		}
+
+		// Use confidence score as reference time proxy:
+		// If we have no LastVerifiedAt, use a reference time of 0 (epoch)
+		// which means any existing file will appear stale on first check.
+		// This is intentional -- it triggers the first freshness annotation.
+		refTime := time.Time{} // epoch -- forces first check to be informative
+		// In the future, this will be node.LastVerifiedAt from the DB
+
+		result := freshness.Check(basePath, string(evJSON), refTime)
+
+		node.FreshnessStatus = string(result.Status)
+		node.FreshnessNote = freshness.FormatStatus(result, nil)
+		node.StaleFiles = result.StaleFiles
+
+		// Adjust confidence if stale or missing
+		if result.DecayFactor < 1.0 && node.ConfidenceScore > 0 {
+			node.ConfidenceScore = node.ConfidenceScore * result.DecayFactor
+			if node.ConfidenceScore < 0.1 {
+				node.ConfidenceScore = 0.1
+			}
+		}
 	}
 }

--- a/internal/app/ask.go
+++ b/internal/app/ask.go
@@ -552,12 +552,13 @@ func annotateResultFreshness(basePath string, results []knowledge.NodeResponse) 
 			continue
 		}
 
-		// Use confidence score as reference time proxy:
-		// If we have no LastVerifiedAt, use a reference time of 0 (epoch)
-		// which means any existing file will appear stale on first check.
-		// This is intentional -- it triggers the first freshness annotation.
-		refTime := time.Time{} // epoch -- forces first check to be informative
-		// In the future, this will be node.LastVerifiedAt from the DB
+		// Use node creation time as the reference. Files modified after the
+		// node was created indicate the knowledge may be stale.
+		refTime := node.CreatedAt
+		if refTime.IsZero() {
+			// Fallback: if no creation time, treat as stale to be safe
+			refTime = time.Now().Add(-24 * time.Hour)
+		}
 
 		result := freshness.Check(basePath, string(evJSON), refTime)
 

--- a/internal/bootstrap/initializer.go
+++ b/internal/bootstrap/initializer.go
@@ -1086,7 +1086,7 @@ const taskwingDocSectionHeader = `
 
 ## TaskWing Integration
 
-TaskWing helps turn a goal into executed tasks with persistent context across AI sessions.
+TaskWing extracts architectural knowledge from your codebase and stores it locally, giving every AI tool instant context via MCP.
 
 ### Supported Models
 

--- a/internal/freshness/freshness.go
+++ b/internal/freshness/freshness.go
@@ -76,7 +76,6 @@ func Check(basePath string, evidenceJSON string, referenceTime time.Time) Result
 	}
 
 	var stale, missing []string
-	checked := 0
 
 	for _, p := range paths {
 		fullPath := p
@@ -92,7 +91,6 @@ func Check(basePath string, evidenceJSON string, referenceTime time.Time) Result
 			// Permission errors and other failures: skip, don't count as stale
 			continue
 		}
-		checked++
 
 		if info.ModTime().After(referenceTime) {
 			stale = append(stale, p)
@@ -145,7 +143,8 @@ func Check(basePath string, evidenceJSON string, referenceTime time.Time) Result
 func shouldSkip(path string) bool {
 	normalized := filepath.ToSlash(path)
 	for _, pattern := range skipPatterns {
-		if strings.HasPrefix(normalized, pattern) {
+		// Match at start (dist/...) or as a path segment (api/dist/...)
+		if strings.HasPrefix(normalized, pattern) || strings.Contains(normalized, "/"+pattern) {
 			return true
 		}
 	}

--- a/internal/freshness/freshness.go
+++ b/internal/freshness/freshness.go
@@ -1,0 +1,229 @@
+// Package freshness provides query-time validation of knowledge graph findings.
+// It checks whether evidence files have changed since findings were last verified,
+// adjusting confidence scores and adding staleness metadata to MCP responses.
+package freshness
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Status describes the freshness of a finding's evidence.
+type Status string
+
+const (
+	StatusFresh      Status = "fresh"       // All evidence files unchanged
+	StatusStale      Status = "stale"       // Some evidence files changed since last check
+	StatusMissing    Status = "missing"     // Some evidence files no longer exist
+	StatusNoEvidence Status = "no_evidence" // Finding has no file-based evidence
+	StatusUnknown    Status = "unknown"     // Could not determine (permission error, timeout, etc.)
+)
+
+// Result captures the outcome of a freshness check for a single node.
+type Result struct {
+	Status       Status   `json:"status"`
+	StaleFiles   []string `json:"staleFiles,omitempty"`
+	MissingFiles []string `json:"missingFiles,omitempty"`
+	DecayFactor  float64  `json:"decayFactor"`
+	CheckedAt    time.Time
+}
+
+// evidenceItem is the subset of evidence fields we need for freshness checks.
+type evidenceItem struct {
+	FilePath string `json:"file_path"`
+}
+
+// skipPatterns are path prefixes for build artifacts and generated files.
+// Changes to these should not trigger staleness.
+var skipPatterns = []string{
+	"dist/", "build/", "node_modules/", "vendor/",
+	".next/", "__pycache__/", "target/", ".gradle/",
+	".taskwing/", ".git/",
+}
+
+// Check performs a Level 1 (stat-based) freshness check on a node's evidence.
+// It compares file mtimes against the reference time (typically node creation or last verification).
+// Designed to be fast enough to run inline on every MCP query (<1ms per node).
+func Check(basePath string, evidenceJSON string, referenceTime time.Time) Result {
+	if evidenceJSON == "" {
+		return Result{Status: StatusNoEvidence, DecayFactor: 1.0, CheckedAt: time.Now()}
+	}
+
+	var evidence []evidenceItem
+	if err := json.Unmarshal([]byte(evidenceJSON), &evidence); err != nil {
+		return Result{Status: StatusNoEvidence, DecayFactor: 1.0, CheckedAt: time.Now()}
+	}
+
+	// Filter to evidence items with file paths
+	var paths []string
+	for _, e := range evidence {
+		if e.FilePath == "" {
+			continue
+		}
+		if shouldSkip(e.FilePath) {
+			continue
+		}
+		paths = append(paths, e.FilePath)
+	}
+
+	if len(paths) == 0 {
+		return Result{Status: StatusNoEvidence, DecayFactor: 1.0, CheckedAt: time.Now()}
+	}
+
+	var stale, missing []string
+	checked := 0
+
+	for _, p := range paths {
+		fullPath := p
+		if !filepath.IsAbs(p) {
+			fullPath = filepath.Join(basePath, p)
+		}
+
+		info, err := statCached(fullPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				missing = append(missing, p)
+			}
+			// Permission errors and other failures: skip, don't count as stale
+			continue
+		}
+		checked++
+
+		if info.ModTime().After(referenceTime) {
+			stale = append(stale, p)
+		}
+	}
+
+	now := time.Now()
+
+	// All evidence files deleted
+	if len(missing) == len(paths) {
+		return Result{
+			Status:       StatusMissing,
+			MissingFiles: missing,
+			DecayFactor:  0.2,
+			CheckedAt:    now,
+		}
+	}
+
+	// Some files missing
+	if len(missing) > 0 {
+		missingRatio := float64(len(missing)) / float64(len(paths))
+		decay := 1.0 - (missingRatio * 0.6) // 0.4 at 100% missing
+		return Result{
+			Status:       StatusMissing,
+			StaleFiles:   stale,
+			MissingFiles: missing,
+			DecayFactor:  decay,
+			CheckedAt:    now,
+		}
+	}
+
+	// Some files changed
+	if len(stale) > 0 {
+		return Result{
+			Status:      StatusStale,
+			StaleFiles:  stale,
+			DecayFactor: 0.7,
+			CheckedAt:   now,
+		}
+	}
+
+	// All fresh
+	return Result{
+		Status:      StatusFresh,
+		DecayFactor: 1.0,
+		CheckedAt:   now,
+	}
+}
+
+func shouldSkip(path string) bool {
+	normalized := filepath.ToSlash(path)
+	for _, pattern := range skipPatterns {
+		if strings.HasPrefix(normalized, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// FormatStatus returns a human-readable annotation for MCP responses.
+func FormatStatus(r Result, lastVerified *time.Time) string {
+	switch r.Status {
+	case StatusFresh:
+		if lastVerified != nil {
+			age := time.Since(*lastVerified)
+			return fmt.Sprintf("[verified %s ago]", formatDuration(age))
+		}
+		return "[fresh]"
+	case StatusStale:
+		files := strings.Join(r.StaleFiles, ", ")
+		if len(files) > 60 {
+			files = fmt.Sprintf("%d files changed", len(r.StaleFiles))
+		}
+		return fmt.Sprintf("[STALE: %s]", files)
+	case StatusMissing:
+		return "[WARNING: evidence file deleted]"
+	case StatusNoEvidence:
+		return ""
+	default:
+		return ""
+	}
+}
+
+func formatDuration(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}
+
+// --- Stat cache (avoids re-statting the same file within a session) ---
+
+var (
+	cache   = make(map[string]cacheEntry)
+	cacheMu sync.RWMutex
+	cacheTTL = 60 * time.Second
+)
+
+type cacheEntry struct {
+	info      os.FileInfo
+	err       error
+	checkedAt time.Time
+}
+
+func statCached(path string) (os.FileInfo, error) {
+	cacheMu.RLock()
+	entry, ok := cache[path]
+	cacheMu.RUnlock()
+
+	if ok && time.Since(entry.checkedAt) < cacheTTL {
+		return entry.info, entry.err
+	}
+
+	info, err := os.Stat(path)
+
+	cacheMu.Lock()
+	cache[path] = cacheEntry{info: info, err: err, checkedAt: time.Now()}
+	cacheMu.Unlock()
+
+	return info, err
+}
+
+// ResetCache clears the stat cache. Used in tests and after bootstrap.
+func ResetCache() {
+	cacheMu.Lock()
+	cache = make(map[string]cacheEntry)
+	cacheMu.Unlock()
+}

--- a/internal/freshness/freshness_test.go
+++ b/internal/freshness/freshness_test.go
@@ -1,0 +1,223 @@
+package freshness
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCheckFresh(t *testing.T) {
+	ResetCache()
+	dir := t.TempDir()
+
+	// Create a file that's older than the reference time
+	filePath := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(filePath, []byte("package main"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reference time is in the future (file is older)
+	evidence := mustJSON(t, []evidenceItem{{FilePath: "main.go"}})
+	result := Check(dir, evidence, time.Now().Add(time.Hour))
+
+	if result.Status != StatusFresh {
+		t.Fatalf("expected fresh, got %s", result.Status)
+	}
+	if result.DecayFactor != 1.0 {
+		t.Fatalf("expected decay 1.0, got %f", result.DecayFactor)
+	}
+}
+
+func TestCheckStale(t *testing.T) {
+	ResetCache()
+	dir := t.TempDir()
+
+	filePath := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(filePath, []byte("package main"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reference time is in the past (file is newer)
+	result := Check(dir, mustJSON(t, []evidenceItem{{FilePath: "main.go"}}), time.Now().Add(-time.Hour))
+
+	if result.Status != StatusStale {
+		t.Fatalf("expected stale, got %s", result.Status)
+	}
+	if len(result.StaleFiles) != 1 {
+		t.Fatalf("expected 1 stale file, got %d", len(result.StaleFiles))
+	}
+	if result.DecayFactor != 0.7 {
+		t.Fatalf("expected decay 0.7, got %f", result.DecayFactor)
+	}
+}
+
+func TestCheckMissing(t *testing.T) {
+	ResetCache()
+	dir := t.TempDir()
+
+	result := Check(dir, mustJSON(t, []evidenceItem{{FilePath: "gone.go"}}), time.Now())
+
+	if result.Status != StatusMissing {
+		t.Fatalf("expected missing, got %s", result.Status)
+	}
+	if len(result.MissingFiles) != 1 {
+		t.Fatalf("expected 1 missing file, got %d", len(result.MissingFiles))
+	}
+	if result.DecayFactor != 0.2 {
+		t.Fatalf("expected decay 0.2 for all-missing, got %f", result.DecayFactor)
+	}
+}
+
+func TestCheckNoEvidence(t *testing.T) {
+	ResetCache()
+	result := Check("/tmp", "", time.Now())
+
+	if result.Status != StatusNoEvidence {
+		t.Fatalf("expected no_evidence, got %s", result.Status)
+	}
+	if result.DecayFactor != 1.0 {
+		t.Fatalf("expected decay 1.0, got %f", result.DecayFactor)
+	}
+}
+
+func TestCheckEmptyEvidenceArray(t *testing.T) {
+	ResetCache()
+	result := Check("/tmp", "[]", time.Now())
+
+	if result.Status != StatusNoEvidence {
+		t.Fatalf("expected no_evidence for empty array, got %s", result.Status)
+	}
+}
+
+func TestCheckSkipsBuildArtifacts(t *testing.T) {
+	ResetCache()
+	dir := t.TempDir()
+
+	// Create file in node_modules (should be skipped)
+	nmDir := filepath.Join(dir, "node_modules")
+	if err := os.MkdirAll(nmDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nmDir, "dep.js"), []byte("module.exports = {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	evidence := mustJSON(t, []evidenceItem{{FilePath: "node_modules/dep.js"}})
+	result := Check(dir, evidence, time.Now().Add(-time.Hour))
+
+	// Should be no_evidence since the only evidence file was skipped
+	if result.Status != StatusNoEvidence {
+		t.Fatalf("expected no_evidence (build artifact skipped), got %s", result.Status)
+	}
+}
+
+func TestCheckMixedStaleAndFresh(t *testing.T) {
+	ResetCache()
+	dir := t.TempDir()
+
+	// Create two files
+	if err := os.WriteFile(filepath.Join(dir, "fresh.go"), []byte("package a"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "stale.go"), []byte("package b"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reference time: after fresh.go was written but before "now"
+	// Both files have same mtime (just created), so use a past reference to make both stale
+	// or a future reference to make both fresh
+	refTime := time.Now().Add(-time.Hour)
+
+	evidence := mustJSON(t, []evidenceItem{
+		{FilePath: "fresh.go"},
+		{FilePath: "stale.go"},
+	})
+	result := Check(dir, evidence, refTime)
+
+	if result.Status != StatusStale {
+		t.Fatalf("expected stale, got %s", result.Status)
+	}
+}
+
+func TestCheckPartialMissing(t *testing.T) {
+	ResetCache()
+	dir := t.TempDir()
+
+	// One file exists, one doesn't
+	if err := os.WriteFile(filepath.Join(dir, "exists.go"), []byte("package a"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	evidence := mustJSON(t, []evidenceItem{
+		{FilePath: "exists.go"},
+		{FilePath: "deleted.go"},
+	})
+	result := Check(dir, evidence, time.Now().Add(time.Hour))
+
+	if result.Status != StatusMissing {
+		t.Fatalf("expected missing, got %s", result.Status)
+	}
+	if result.DecayFactor >= 0.8 {
+		t.Fatalf("expected significant decay for partial missing, got %f", result.DecayFactor)
+	}
+}
+
+func TestFormatStatusFresh(t *testing.T) {
+	now := time.Now().Add(-2 * time.Hour)
+	s := FormatStatus(Result{Status: StatusFresh}, &now)
+	if s != "[verified 2h ago]" {
+		t.Fatalf("unexpected format: %q", s)
+	}
+}
+
+func TestFormatStatusStale(t *testing.T) {
+	s := FormatStatus(Result{Status: StatusStale, StaleFiles: []string{"auth.go"}}, nil)
+	if s != "[STALE: auth.go]" {
+		t.Fatalf("unexpected format: %q", s)
+	}
+}
+
+func TestFormatStatusNoEvidence(t *testing.T) {
+	s := FormatStatus(Result{Status: StatusNoEvidence}, nil)
+	if s != "" {
+		t.Fatalf("expected empty string for no_evidence, got %q", s)
+	}
+}
+
+func TestStatCache(t *testing.T) {
+	ResetCache()
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "cached.go")
+	if err := os.WriteFile(filePath, []byte("package a"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First call: cache miss
+	info1, err1 := statCached(filePath)
+	if err1 != nil {
+		t.Fatal(err1)
+	}
+
+	// Delete the file
+	os.Remove(filePath)
+
+	// Second call: should return cached result (file still "exists")
+	info2, err2 := statCached(filePath)
+	if err2 != nil {
+		t.Fatal("expected cached result, got error")
+	}
+	if info1.ModTime() != info2.ModTime() {
+		t.Fatal("cache returned different result")
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}

--- a/internal/freshness/freshness_test.go
+++ b/internal/freshness/freshness_test.go
@@ -213,6 +213,27 @@ func TestStatCache(t *testing.T) {
 	}
 }
 
+func TestCheckSkipsBuildArtifactsInSubdirectory(t *testing.T) {
+	ResetCache()
+	dir := t.TempDir()
+
+	// Create file in api/node_modules (monorepo pattern -- should be skipped)
+	nmDir := filepath.Join(dir, "api", "node_modules")
+	if err := os.MkdirAll(nmDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nmDir, "dep.js"), []byte("module.exports = {}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	evidence := mustJSON(t, []evidenceItem{{FilePath: "api/node_modules/dep.js"}})
+	result := Check(dir, evidence, time.Now().Add(-time.Hour))
+
+	if result.Status != StatusNoEvidence {
+		t.Fatalf("expected no_evidence (monorepo build artifact skipped), got %s", result.Status)
+	}
+}
+
 func mustJSON(t *testing.T, v any) string {
 	t.Helper()
 	b, err := json.Marshal(v)

--- a/internal/knowledge/response.go
+++ b/internal/knowledge/response.go
@@ -30,6 +30,11 @@ type NodeResponse struct {
 	MatchScore         float32       `json:"matchScore,omitempty"` // Semantic similarity (0-1)
 	Evidence           []EvidenceRef `json:"evidence,omitempty"`   // File:line references
 
+	// Freshness metadata (set at query time by freshness.Check, not stored)
+	FreshnessStatus string   `json:"freshnessStatus,omitempty"` // fresh, stale, missing, no_evidence
+	FreshnessNote   string   `json:"freshnessNote,omitempty"`   // Human-readable: "[verified 2h ago]"
+	StaleFiles      []string `json:"staleFiles,omitempty"`      // Evidence files that changed
+
 	// Debt Classification - distinguishes essential from accidental complexity
 	// When DebtScore >= 0.7, this pattern represents technical debt that shouldn't be propagated
 	DebtScore    float64 `json:"debtScore,omitempty"`    // 0.0 = clean, 1.0 = pure debt

--- a/internal/knowledge/response.go
+++ b/internal/knowledge/response.go
@@ -4,6 +4,7 @@ package knowledge
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/josephgoksu/TaskWing/internal/memory"
 )
@@ -29,6 +30,7 @@ type NodeResponse struct {
 	VerificationStatus string        `json:"verificationStatus,omitempty"`
 	MatchScore         float32       `json:"matchScore,omitempty"` // Semantic similarity (0-1)
 	Evidence           []EvidenceRef `json:"evidence,omitempty"`   // File:line references
+	CreatedAt          time.Time     `json:"createdAt,omitempty"`  // When the node was created
 
 	// Freshness metadata (set at query time by freshness.Check, not stored)
 	FreshnessStatus string   `json:"freshnessStatus,omitempty"` // fresh, stale, missing, no_evidence
@@ -54,6 +56,7 @@ func NodeToResponse(n memory.Node, matchScore float32) NodeResponse {
 		VerificationStatus: n.VerificationStatus,
 		MatchScore:         matchScore,
 		Evidence:           parseEvidence(n.Evidence),
+		CreatedAt:          n.CreatedAt,
 		DebtScore:          n.DebtScore,
 		DebtReason:         n.DebtReason,
 		RefactorHint:       n.RefactorHint,

--- a/internal/knowledge/service.go
+++ b/internal/knowledge/service.go
@@ -138,7 +138,7 @@ func (s *Service) RewriteQuery(ctx context.Context, query string) (string, error
 
 	// Use a domain-aware prompt for query rewriting
 	// Include context about TaskWing to help fix domain-specific typos
-	prompt := fmt.Sprintf(`You are improving a search query for TaskWing, a developer tool that gives AI coding assistants permanent memory about codebases.
+	prompt := fmt.Sprintf(`You are improving a search query for TaskWing, a local-first AI knowledge layer that extracts architectural decisions, patterns, and constraints from codebases.
 
 Rules:
 1. Fix typos (e.g., "TaskWink" → "TaskWing", "teh" → "the")

--- a/internal/mcp/presenter.go
+++ b/internal/mcp/presenter.go
@@ -38,8 +38,11 @@ func FormatAsk(result *app.AskResult) string {
 	if len(result.Results) > 0 {
 		sb.WriteString("## Knowledge\n")
 		for i, node := range result.Results {
-			// Format: 1. **Title** (type) - content preview
+			// Format: 1. **Title** (type) [freshness] - content preview
 			sb.WriteString(fmt.Sprintf("%d. **%s** (%s)", i+1, node.Summary, node.Type))
+			if node.FreshnessNote != "" {
+				sb.WriteString(fmt.Sprintf(" %s", node.FreshnessNote))
+			}
 			if node.Content != "" && node.Content != node.Summary {
 				// Add content preview (first 150 chars)
 				content := cleanContent(node.Content, node.Summary)

--- a/internal/memory/models.go
+++ b/internal/memory/models.go
@@ -40,6 +40,15 @@ type Node struct {
 	// ConfidenceScore is numeric confidence (0.0-1.0) adjusted by verification
 	ConfidenceScore float64 `json:"confidenceScore,omitempty"`
 
+	// Freshness Validation fields (v2.3+)
+	// These support query-time staleness detection for evidence files
+
+	// LastVerifiedAt is when the last freshness check ran (nil = never checked)
+	LastVerifiedAt *time.Time `json:"lastVerifiedAt,omitempty"`
+
+	// OriginalConfidence is the confidence at ingest time, before any freshness decay
+	OriginalConfidence *float64 `json:"originalConfidence,omitempty"`
+
 	// Debt Classification fields (v2.2+)
 	// Distinguishes essential complexity from accidental complexity (technical debt).
 	// When AI retrieves context, high-debt patterns include warnings to prevent propagation.

--- a/internal/memory/sqlite.go
+++ b/internal/memory/sqlite.go
@@ -64,6 +64,10 @@ func NewSQLiteStore(basePath string) (*SQLiteStore, error) {
 	migrateAddColumn(db, "plans", "generation_mode", `ALTER TABLE plans ADD COLUMN generation_mode TEXT DEFAULT 'batch'`)
 	migrateAddColumn(db, "tasks", "phase_id", `ALTER TABLE tasks ADD COLUMN phase_id TEXT REFERENCES phases(id) ON DELETE SET NULL`)
 
+	// Freshness validation columns (v2.3+)
+	migrateAddColumn(db, "nodes", "last_verified_at", `ALTER TABLE nodes ADD COLUMN last_verified_at TEXT`)
+	migrateAddColumn(db, "nodes", "original_confidence", `ALTER TABLE nodes ADD COLUMN original_confidence REAL`)
+
 	return store, nil
 }
 
@@ -2442,4 +2446,42 @@ func (s *SQLiteStore) NeedsToolUpdate(toolName, expectedVersion string) (bool, e
 		return true, nil // Not installed
 	}
 	return tv.CommandHash != expectedVersion, nil
+}
+
+// UpdateNodeFreshness updates the freshness validation fields for a node.
+func (s *SQLiteStore) UpdateNodeFreshness(nodeID string, lastVerifiedAt time.Time, originalConfidence *float64) error {
+	var origConf sql.NullFloat64
+	if originalConfidence != nil {
+		origConf = sql.NullFloat64{Float64: *originalConfidence, Valid: true}
+	}
+	_, err := s.db.Exec(`
+		UPDATE nodes SET last_verified_at = ?, original_confidence = ?
+		WHERE id = ?
+	`, lastVerifiedAt.Format(time.RFC3339), origConf, nodeID)
+	if err != nil {
+		return fmt.Errorf("update node freshness: %w", err)
+	}
+	return nil
+}
+
+// GetNodeFreshness retrieves freshness fields for a node without loading the full node.
+func (s *SQLiteStore) GetNodeFreshness(nodeID string) (lastVerifiedAt *time.Time, originalConfidence *float64, err error) {
+	var lvStr sql.NullString
+	var origConf sql.NullFloat64
+	err = s.db.QueryRow(`
+		SELECT last_verified_at, original_confidence FROM nodes WHERE id = ?
+	`, nodeID).Scan(&lvStr, &origConf)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get node freshness: %w", err)
+	}
+	if lvStr.Valid {
+		t, parseErr := time.Parse(time.RFC3339, lvStr.String)
+		if parseErr == nil {
+			lastVerifiedAt = &t
+		}
+	}
+	if origConf.Valid {
+		originalConfidence = &origConf.Float64
+	}
+	return lastVerifiedAt, originalConfidence, nil
 }


### PR DESCRIPTION
## Summary

Two major workstreams in one branch:

### 1. Local-first positioning overhaul
- Reposition from "AI task manager" to "local-first AI knowledge layer"
- Update tagline, hero copy, and privacy section across all docs (README, PRODUCT_VISION, TUTORIAL, CLAUDE.md, GEMINI.md, AGENTS.md)
- Add honest "Private by Architecture" section with ASCII data flow diagram showing what TaskWing controls vs what the AI tool controls
- Update CLI help text and LLM prompt to match new positioning
- Add 5-phase positioning research (messaging framework, market validation, copy recommendations, credibility audit, SEO alignment)

### 2. Query-time freshness validation (Level 1)
- New `internal/freshness` package: stat-based validation of evidence files at MCP query time
- When `ask` returns knowledge findings, check if evidence files changed since the finding was created
- Stale findings get confidence decayed (0.7x stale, 0.2x all-missing, floor 0.1)
- MCP responses annotated: `[verified 2h ago]`, `[STALE: auth.go changed]`, `[WARNING: evidence file deleted]`
- 60-second stat cache to avoid repeated syscalls across queries
- Skip patterns for build artifacts (dist/, node_modules/, vendor/)
- Schema migration: `last_verified_at` and `original_confidence` columns on nodes table
- 13 tests covering fresh, stale, missing, no-evidence, cache, skip patterns

### 3. Planning docs
- Multi-agent bootstrap pipeline plan (4 internal post-processing agents)
- Tool template system plan (single-file self-registering tool pattern)
- Freshness validation architecture plan

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1 -short` -- 206 tests pass across 33 packages
- [x] `go vet ./...` clean
- [x] Doc marker consistency verified across README, CLAUDE, GEMINI, VISION, TUTORIAL
- [x] No old positioning language in production code or user-facing docs
- [x] QA review found and fixed 3 freshness defects (epoch reference time, dead variable, monorepo skip)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR delivers two parallel workstreams: a comprehensive local-first positioning overhaul across all docs/CLI, and a Level 1 query-time freshness validation system for the knowledge graph.

- **Positioning overhaul** is thorough and consistent — tagline, hero copy, CLI help text, LLM prompts, and all 7 doc files updated with matching language. The new "Private by Architecture" section with ASCII data flow diagrams is honest about trust boundaries (what TaskWing controls vs what AI tools control).
- **Freshness validation** (`internal/freshness/`) adds stat-based evidence file checking at MCP query time, with confidence decay for stale/missing files. The core logic is sound and well-tested with 13 tests covering fresh, stale, missing, no-evidence, cache, and skip patterns.
- **Key concern**: The partial-missing decay formula has a discontinuity — jumping from 0.7 (1 of 2 files missing) to 0.2 (2 of 2 missing) is a 3.5x confidence cliff that seems unintentional.
- **Dead code**: `UpdateNodeFreshness()`, `GetNodeFreshness()`, the `last_verified_at`/`original_confidence` schema columns, and the `[verified Xh ago]` format path are all unreachable — shipped for future Level 2 but adding maintenance burden now.
- **Global stat cache** grows unboundedly. Works fine for current scale but will leak memory for large projects in long-running MCP server processes.
- **Planning docs** have drifted from the implementation (missing `LastVerifiedLevel`, different function signatures, different decay factors).
</details>

<h3>Confidence Score: 3/5</h3>

- PR is safe to merge with minor issues — the decay discontinuity should be reviewed but won't cause crashes.
- Score of 3 reflects: solid test coverage and clean doc consistency, offset by a logic discontinuity in the decay formula, dead code shipped prematurely (schema columns + methods never called), and an unbounded global cache. None are blockers, but the decay behavior may produce surprising confidence scores for users.
- Pay close attention to `internal/freshness/freshness.go` (decay discontinuity, unbounded cache) and `internal/app/ask.go` (dead persistence path, fallback reference time).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| internal/freshness/freshness.go | New stat-based freshness checker. Global package-level mutable cache is a concurrency concern for long-running server processes and complicates testing. Partial-missing decay has a code path conflict (unreachable 0.2 vs formula 0.4). |
| internal/freshness/freshness_test.go | 13 tests with good coverage across fresh, stale, missing, no-evidence, cache, and skip patterns. Tests properly call ResetCache() to isolate state. |
| internal/app/ask.go | Adds freshness annotation to query results. Evidence JSON is re-serialized from parsed EvidenceRef (lossy round-trip). Freshness check results and `last_verified_at` are never persisted back to the database despite schema support. |
| internal/knowledge/response.go | Adds freshness metadata fields (FreshnessStatus, FreshnessNote, StaleFiles) and CreatedAt to NodeResponse. Clean additions. |
| internal/mcp/presenter.go | Cleanly adds freshness annotation to MCP response formatting. Minimal, correct change. |
| internal/memory/models.go | Adds LastVerifiedAt and OriginalConfidence fields to Node struct. Plan mentions LastVerifiedLevel (int) but it was not implemented -- minor doc/code divergence. |
| internal/memory/sqlite.go | Adds schema migration for freshness columns and CRUD methods. UpdateNodeFreshness and GetNodeFreshness are defined but never called by any code path in this PR. |
| cmd/root.go | CLI help text updated to reflect local-first positioning. Clean change. |
| README.md | Comprehensive positioning overhaul with new privacy architecture section and ASCII data flow diagram. Well-written and honest about trust boundaries. |
| docs/positioning/freshness-validation-plan.md | Detailed plan for query-time freshness. Some drift from implementation (LastVerifiedLevel not implemented, function name differs, decay factors don't match code). |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant AI as AI Tool (MCP Client)
    participant MCP as MCP Server (presenter.go)
    participant Ask as AskApp.Query (ask.go)
    participant KS as Knowledge Service
    participant SQLite as SQLite (memory.db)
    participant Fresh as freshness.Check
    participant FS as Filesystem (os.Stat)

    AI->>MCP: ask("how does auth work?")
    MCP->>Ask: Query(ctx, query, opts)
    Ask->>KS: Search(ctx, query, limit)
    KS->>SQLite: SearchFTS / VectorSearch
    SQLite-->>KS: []ScoredNode (with CreatedAt)
    KS-->>Ask: []ScoredNode
    Ask->>Ask: Convert to []NodeResponse

    rect rgb(255, 245, 230)
        Note over Ask,FS: Freshness Validation (new in this PR)
        loop For each NodeResponse
            Ask->>Fresh: Check(basePath, evidenceJSON, createdAt)
            Fresh->>FS: statCached(evidencePath)
            FS-->>Fresh: FileInfo.ModTime
            Fresh-->>Ask: Result{Status, DecayFactor}
            Ask->>Ask: Adjust ConfidenceScore × DecayFactor
            Ask->>Ask: Set FreshnessNote annotation
        end
    end

    Ask-->>MCP: AskResult (annotated)
    MCP->>MCP: FormatAsk (includes [STALE: ...] notes)
    MCP-->>AI: Markdown response with freshness metadata
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Ainternal%2Ffreshness%2Ffreshness.go%3A193-197%0A**Global%20mutable%20cache%20risks%20stale%20state%20across%20tests%20and%20long-running%20processes**%0A%0AThe%20stat%20cache%20is%20a%20package-level%20global%20with%20a%20%60sync.RWMutex%60.%20While%20%60ResetCache%28%29%60%20exists%20for%20tests%2C%20this%20design%20has%20two%20concrete%20problems%3A%0A%0A1.%20**Unbounded%20growth**%3A%20The%20cache%20%60map%5Bstring%5DcacheEntry%60%20grows%20forever%20%E2%80%94%20entries%20expire%20by%20TTL%20but%20are%20never%20evicted.%20For%20a%20project%20with%20thousands%20of%20evidence%20files%2C%20this%20leaks%20memory%20over%20the%20lifetime%20of%20an%20MCP%20server%20process.%0A%0A2.%20**Testability**%3A%20Any%20test%20that%20forgets%20%60ResetCache%28%29%60%20inherits%20stale%20state%20from%20prior%20tests.%20This%20is%20fragile%20%E2%80%94%20a%20test%20reorder%20or%20parallelism%20change%20can%20cause%20intermittent%20failures.%0A%0AConsider%20either%20%28a%29%20adding%20a%20periodic%20eviction%20sweep%20%28e.g.%2C%20purge%20entries%20older%20than%202x%20TTL%20when%20cache%20exceeds%20N%20entries%29%2C%20or%20%28b%29%20making%20the%20cache%20an%20instance%20field%20on%20a%20%60Checker%60%20struct%20so%20each%20caller%20owns%20its%20own%20lifecycle.%20Option%20%28b%29%20also%20makes%20it%20trivially%20testable%20without%20global%20mutation.%0A%0A%23%23%23%20Issue%202%20of%205%0Ainternal%2Ffreshness%2Ffreshness.go%3A102-122%0A**Partial-missing%20decay%20formula%20contradicts%20all-missing%20constant**%0A%0AWhen%20all%20evidence%20files%20are%20missing%20%28%60len%28missing%29%20%3D%3D%20len%28paths%29%60%29%2C%20the%20decay%20is%20hardcoded%20to%20%600.2%60%20%28line%20107%29.%20But%20when%20%22some%20files%20are%20missing%22%2C%20the%20formula%20on%20line%20115%20is%3A%0A%0A%60%60%60%0Adecay%20%3D%201.0%20-%20%28missingRatio%20*%200.6%29%0A%60%60%60%0A%0AAt%20%60missingRatio%20%3D%201.0%60%20%28which%20is%20checked%20and%20returned%20early%20above%29%2C%20this%20formula%20would%20yield%20%600.4%60%20%E2%80%94%20not%20%600.2%60.%20This%20means%20there's%20a%20discontinuity%3A%20if%20you%20have%202%20evidence%20files%20and%20both%20are%20missing%2C%20you%20get%20%600.2%60.%20But%20if%20you%20have%202%20evidence%20files%20and%201%20is%20missing%2C%20you%20get%20%601.0%20-%20%280.5%20*%200.6%29%20%3D%200.7%60.%20%0A%0AThe%20jump%20from%20%600.7%60%20%281%20of%202%20missing%29%20to%20%600.2%60%20%282%20of%202%20missing%29%20is%20a%203.5x%20confidence%20cliff.%20This%20feels%20unintentional%20%E2%80%94%20if%20the%20formula%20is%20the%20intended%20behavior%20for%20partial%20missing%2C%20the%20all-missing%20case%20should%20probably%20use%20the%20same%20formula%20%28%600.4%60%29%20or%20the%20formula%20constant%20should%20be%20%600.8%60%20so%20partial%20approaches%20%600.2%60%20smoothly.%0A%0A%23%23%23%20Issue%203%20of%205%0Ainternal%2Fapp%2Fask.go%3A531-576%0A**Freshness%20results%20and%20%60last_verified_at%60%20are%20never%20persisted%20to%20the%20database**%0A%0AThe%20schema%20migration%20adds%20%60last_verified_at%60%20and%20%60original_confidence%60%20columns%2C%20and%20%60sqlite.go%60%20defines%20%60UpdateNodeFreshness%28%29%60%20%2F%20%60GetNodeFreshness%28%29%60%20methods%20%E2%80%94%20but%20%60annotateResultFreshness%60%20never%20calls%20them.%20Every%20query%20re-stats%20every%20evidence%20file%20from%20scratch%2C%20and%20the%20%60FormatStatus%60%20call%20on%20line%20566%20always%20passes%20%60nil%60%20for%20%60lastVerified%60%2C%20meaning%20fresh%20nodes%20always%20display%20%60%5Bfresh%5D%60%20instead%20of%20%60%5Bverified%202h%20ago%5D%60.%0A%0AThis%20means%3A%0A1.%20The%20%60%5Bverified%20Xh%20ago%5D%60%20annotation%20path%20in%20%60FormatStatus%60%20is%20dead%20code%20in%20practice%20%E2%80%94%20it%20can%20never%20be%20reached.%0A2.%20The%20%60UpdateNodeFreshness%60%20and%20%60GetNodeFreshness%60%20methods%20in%20%60sqlite.go%60%20are%20dead%20code%20%E2%80%94%20never%20called%20anywhere.%0A3.%20Every%20MCP%20query%20redundantly%20re-stats%20all%20evidence%20files%20even%20when%20nothing%20changed.%0A%0AIf%20this%20is%20intentional%20for%20Level%201%20%28persist%20later%20in%20Level%202%2B%29%2C%20that's%20fine%20%E2%80%94%20but%20the%20dead%20code%20should%20be%20flagged%20with%20a%20%60%2F%2F%20TODO%28freshness-level2%29%60%20comment%2C%20and%20the%20schema%20columns%20should%20arguably%20be%20deferred%20until%20they're%20actually%20written%20to.%20Shipping%20dead%20schema%20%2B%20dead%20methods%20increases%20maintenance%20burden%20for%20zero%20current%20value.%0A%0A%23%23%23%20Issue%204%20of%205%0Ainternal%2Fapp%2Fask.go%3A556-561%0A**Fallback%20reference%20time%20biases%20all%20nodes%20without%20%60CreatedAt%60%20toward%20stale**%0A%0AWhen%20%60refTime.IsZero%28%29%60%2C%20the%20fallback%20is%20%60time.Now%28%29.Add%28-24%20*%20time.Hour%29%60.%20This%20means%20any%20file%20modified%20in%20the%20last%2024%20hours%20will%20make%20the%20node%20appear%20stale%20%E2%80%94%20even%20though%20the%20node%20could%20have%20been%20created%20moments%20ago%20%28if%20%60CreatedAt%60%20wasn't%20persisted%20for%20some%20reason%29.%20%0A%0AFor%20the%20current%20codebase%20this%20may%20be%20acceptable%20since%20%60CreateNode%60%20in%20%60sqlite.go%3A763%60%20defaults%20%60CreatedAt%60%20to%20%60time.Now%28%29.UTC%28%29%60%20when%20zero.%20But%20if%20nodes%20are%20ever%20imported%20or%20migrated%20without%20%60created_at%60%2C%20they'll%20all%20be%20marked%20stale%20by%20default.%20Consider%20logging%20a%20warning%20here%20so%20this%20edge%20case%20is%20visible%20during%20debugging.%0A%0A%60%60%60suggestion%0A%09%09refTime%20%3A%3D%20node.CreatedAt%0A%09%09if%20refTime.IsZero%28%29%20%7B%0A%09%09%09%2F%2F%20Fallback%3A%20if%20no%20creation%20time%2C%20treat%20as%20stale%20to%20be%20safe.%0A%09%09%09%2F%2F%20This%20can%20happen%20with%20imported%20or%20pre-v2.3%20nodes%20missing%20created_at.%0A%09%09%09refTime%20%3D%20time.Now%28%29.Add%28-24%20*%20time.Hour%29%0A%09%09%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%205%20of%205%0Adocs%2Fpositioning%2Ffreshness-validation-plan.md%3A56-60%0A**Plan%20doc%20diverged%20from%20implementation**%0A%0AThree%20discrepancies%20between%20this%20plan%20and%20the%20shipped%20code%3A%0A%0A1.%20**%60LastVerifiedLevel%20int%60**%20is%20in%20the%20plan%20but%20not%20implemented%20in%20%60models.go%60%20or%20the%20schema%20migration.%20The%20plan's%20%60last_verified_level%20INTEGER%20DEFAULT%200%60%20column%20was%20also%20not%20added.%0A2.%20**%60FreshnessAge%20string%60**%20is%20in%20the%20plan's%20%60NodeResponse%60%20spec%20but%20the%20implementation%20uses%20%60FreshnessNote%20string%60%20instead.%0A3.%20**Integration%20function**%3A%20Plan%20says%20%60freshness.ValidateNodeResponses%28ctx%2C%20a.ctx.Repo%2C%20a.ctx.BasePath%2C%20result.Results%29%60%2C%20but%20implementation%20is%20%60annotateResultFreshness%28a.ctx.BasePath%2C%20results%29%60%20%E2%80%94%20a%20local%20function%20that%20doesn't%20take%20%60ctx%60%20or%20%60Repo%60%2C%20meaning%20it%20can't%20persist%20results.%0A4.%20**Decay%20factors**%3A%20Plan%20shows%20single-file-deleted%20as%20%600.4%60%20and%20all-deleted%20as%20%600.2%60.%20Code%20uses%20%600.7%60%20for%20stale%20%28not%20in%20plan%29%20and%20a%20formula%20%601.0%20-%20%28missingRatio%20*%200.6%29%60%20for%20partial%20missing%20%28not%20in%20plan%29.%0A%0AConsider%20updating%20this%20plan%20to%20reflect%20what%20was%20actually%20shipped%2C%20or%20marking%20it%20with%20a%20%22Status%3A%20Implemented%20%28with%20deviations%29%22%20header.%20Stale%20plan%20docs%20become%20misleading%20for%20future%20contributors.%0A%0A&repo=josephgoksu%2Ftaskwing"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/freshness/freshness.go
Line: 193-197

Comment:
**Global mutable cache risks stale state across tests and long-running processes**

The stat cache is a package-level global with a `sync.RWMutex`. While `ResetCache()` exists for tests, this design has two concrete problems:

1. **Unbounded growth**: The cache `map[string]cacheEntry` grows forever — entries expire by TTL but are never evicted. For a project with thousands of evidence files, this leaks memory over the lifetime of an MCP server process.

2. **Testability**: Any test that forgets `ResetCache()` inherits stale state from prior tests. This is fragile — a test reorder or parallelism change can cause intermittent failures.

Consider either (a) adding a periodic eviction sweep (e.g., purge entries older than 2x TTL when cache exceeds N entries), or (b) making the cache an instance field on a `Checker` struct so each caller owns its own lifecycle. Option (b) also makes it trivially testable without global mutation.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/freshness/freshness.go
Line: 102-122

Comment:
**Partial-missing decay formula contradicts all-missing constant**

When all evidence files are missing (`len(missing) == len(paths)`), the decay is hardcoded to `0.2` (line 107). But when "some files are missing", the formula on line 115 is:

```
decay = 1.0 - (missingRatio * 0.6)
```

At `missingRatio = 1.0` (which is checked and returned early above), this formula would yield `0.4` — not `0.2`. This means there's a discontinuity: if you have 2 evidence files and both are missing, you get `0.2`. But if you have 2 evidence files and 1 is missing, you get `1.0 - (0.5 * 0.6) = 0.7`. 

The jump from `0.7` (1 of 2 missing) to `0.2` (2 of 2 missing) is a 3.5x confidence cliff. This feels unintentional — if the formula is the intended behavior for partial missing, the all-missing case should probably use the same formula (`0.4`) or the formula constant should be `0.8` so partial approaches `0.2` smoothly.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/app/ask.go
Line: 531-576

Comment:
**Freshness results and `last_verified_at` are never persisted to the database**

The schema migration adds `last_verified_at` and `original_confidence` columns, and `sqlite.go` defines `UpdateNodeFreshness()` / `GetNodeFreshness()` methods — but `annotateResultFreshness` never calls them. Every query re-stats every evidence file from scratch, and the `FormatStatus` call on line 566 always passes `nil` for `lastVerified`, meaning fresh nodes always display `[fresh]` instead of `[verified 2h ago]`.

This means:
1. The `[verified Xh ago]` annotation path in `FormatStatus` is dead code in practice — it can never be reached.
2. The `UpdateNodeFreshness` and `GetNodeFreshness` methods in `sqlite.go` are dead code — never called anywhere.
3. Every MCP query redundantly re-stats all evidence files even when nothing changed.

If this is intentional for Level 1 (persist later in Level 2+), that's fine — but the dead code should be flagged with a `// TODO(freshness-level2)` comment, and the schema columns should arguably be deferred until they're actually written to. Shipping dead schema + dead methods increases maintenance burden for zero current value.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/app/ask.go
Line: 556-561

Comment:
**Fallback reference time biases all nodes without `CreatedAt` toward stale**

When `refTime.IsZero()`, the fallback is `time.Now().Add(-24 * time.Hour)`. This means any file modified in the last 24 hours will make the node appear stale — even though the node could have been created moments ago (if `CreatedAt` wasn't persisted for some reason). 

For the current codebase this may be acceptable since `CreateNode` in `sqlite.go:763` defaults `CreatedAt` to `time.Now().UTC()` when zero. But if nodes are ever imported or migrated without `created_at`, they'll all be marked stale by default. Consider logging a warning here so this edge case is visible during debugging.

```suggestion
		refTime := node.CreatedAt
		if refTime.IsZero() {
			// Fallback: if no creation time, treat as stale to be safe.
			// This can happen with imported or pre-v2.3 nodes missing created_at.
			refTime = time.Now().Add(-24 * time.Hour)
		}
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: docs/positioning/freshness-validation-plan.md
Line: 56-60

Comment:
**Plan doc diverged from implementation**

Three discrepancies between this plan and the shipped code:

1. **`LastVerifiedLevel int`** is in the plan but not implemented in `models.go` or the schema migration. The plan's `last_verified_level INTEGER DEFAULT 0` column was also not added.
2. **`FreshnessAge string`** is in the plan's `NodeResponse` spec but the implementation uses `FreshnessNote string` instead.
3. **Integration function**: Plan says `freshness.ValidateNodeResponses(ctx, a.ctx.Repo, a.ctx.BasePath, result.Results)`, but implementation is `annotateResultFreshness(a.ctx.BasePath, results)` — a local function that doesn't take `ctx` or `Repo`, meaning it can't persist results.
4. **Decay factors**: Plan shows single-file-deleted as `0.4` and all-deleted as `0.2`. Code uses `0.7` for stale (not in plan) and a formula `1.0 - (missingRatio * 0.6)` for partial missing (not in plan).

Consider updating this plan to reflect what was actually shipped, or marking it with a "Status: Implemented (with deviations)" header. Stale plan docs become misleading for future contributors.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 46a1be4</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->